### PR TITLE
Add support for accent color saturation level

### DIFF
--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -28,13 +28,22 @@ bool UpdateAccentColor()
 		return false;
 	}
 
+	g_dwAccent = dwAccent;
 	if (accentColorChanges >= 1) {
 		g_oldhslAccentS = g_hslAccentS;
 		if (g_oldhslAccentS <= 0.0666) {
 			g_oldhslAccentS = 0.0666;
 		}
 	}
-	else g_oldhslAccentS = 1;
+	else g_oldhslAccentS = pow(double(rgb2hsl({
+			(double)GetRValue(dwAccent) / 254.999999999,
+			(double)GetGValue(dwAccent) / 254.999999999,
+			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.85));
+
+	if (accentColorChanges >= 1) {
+		g_oldhslAccentL = g_hslAccentL;
+	}
+	else g_oldhslAccentL = 0;
 
 	g_dwAccent = dwAccent;
 	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
@@ -71,6 +80,10 @@ bool UpdateAccentColor()
 
 	g_defaulthslAccentH = 207;
 	g_defaulthslAccentS = 1;
+	g_defaulthslAccentL = (double)(rgb2hsl({
+		(double)0 / 254.999999999,
+		(double)120 / 254.999999999,
+		(double)215 / 254.999999999 }).l);
 
 	if (g_hslAccentS < 0.0666) {
 		g_hslAccentS = 0.0666;
@@ -81,10 +94,14 @@ bool UpdateAccentColor()
 		}
 	}
 
-	g_hslAccentL = (double(rgb2hsl({
+	g_hslAccentL = ((double)(rgb2hsl({
 		(double)GetRValue(dwAccent) / 254.999999999,
 		(double)GetGValue(dwAccent) / 254.999999999,
-		(double)GetBValue(dwAccent) / 254.999999999 }).l) - (double)0.4215686) * 255; // based on default accent color #0078D7 (RGB 0, 120, 215)
+		(double)GetBValue(dwAccent) / 254.999999999 }).l) - 
+					(double)(rgb2hsl({
+		(double)0 / 254.999999999,
+		(double)120 / 254.999999999,
+		(double)215 / 254.999999999 }).l)) * -255; // based on default accent color #0078D7 (RGB 0, 120, 215)
 
 	return true;
 }

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -9,6 +9,10 @@ double g_oldhslAccentS;
 double g_balance1hslAccentS;
 double g_balance2hslAccentS;
 double g_oldhslAccentL;
+int g_hslLightAccentH;
+int g_hslDarkAccentH;
+double g_hslEnhancedAccentL{};
+double g_oldhslEnhancedAccentL{};
 
 bool UpdateAccentColor()
 {
@@ -47,13 +51,30 @@ bool UpdateAccentColor()
 			(double)GetGValue(dwAccent) / 255,
 			(double)GetBValue(dwAccent) / 255 }).h;
 	}
-	/* if (g_hslAccentH < 0.0) {
-		g_hslAccentH += 360.0;
+	if (g_hslAccent.h >= 0 && g_hslAccent.h < 120) {
+		g_hslLightAccentH = 60;
 	}
-
-	if (g_hslAccentH > 360.0) {
-		g_hslAccentH -= 360.0;
-	} */
+	else if (g_hslAccent.h >= 120 && g_hslAccent.h < 240) {
+		g_hslLightAccentH = 180;
+	}
+	else if (g_hslAccent.h >= 240 && g_hslAccent.h < 345) {
+		g_hslLightAccentH = 300;
+	}
+	else if (g_hslAccent.h >= 345 && g_hslAccent.h < 360) {
+		g_hslLightAccentH = 420;
+	}
+	if (g_hslAccent.h >= 0 && g_hslAccent.h < 60) {
+		g_hslDarkAccentH = 0;
+	}
+	else if (g_hslAccent.h >= 60 && g_hslAccent.h < 180) {
+		g_hslDarkAccentH = 120;
+	}
+	else if (g_hslAccent.h >= 180 && g_hslAccent.h < 285) {
+		g_hslDarkAccentH = 240;
+	}
+	else if (g_hslAccent.h >= 285 && g_hslAccent.h < 360) {
+		g_hslDarkAccentH = 360;
+	}
 
 	g_dwAccent = dwAccent;
 	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
@@ -63,14 +84,14 @@ bool UpdateAccentColor()
 		g_hslAccent.s = pow(double(rgb2hsl({
 			(double)GetRValue(dwAccent) / 254.999999999,
 			(double)GetGValue(dwAccent) / 254.999999999,
-			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.9));
+			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.95));
 	}
 
 
 	g_balance1hslAccentS = g_hslAccent.s;
 	g_balance2hslAccentS = (1 - g_hslAccent.s);
 
-	g_hslDefaultAccent.h = 207;
+	g_hslDefaultAccent.h = 206.532;
 	g_hslDefaultAccent.s = 1;
 	g_hslDefaultAccent.l = (double)(rgb2hsl({
 		(double)0 / 255,
@@ -86,14 +107,16 @@ bool UpdateAccentColor()
 		}
 	}
 
+
 	g_hslAccent.l = ((double)(rgb2hsl({
 		(double)GetRValue(dwAccent) / 255,
 		(double)GetGValue(dwAccent) / 255,
-		(double)GetBValue(dwAccent) / 255 }).l) - 
-					(double)(rgb2hsl({
+		(double)GetBValue(dwAccent) / 255 }).l) - (double)(rgb2hsl({
 		(double)0 / 255,
-		(double)120 / 255,
-		(double)215 / 255 }).l)) * -255; // based on default accent color #0078D7 (RGB 0, 120, 215)
+		(double)110 / 255,
+		(double)199 / 255 }).l)) * -255.0; // based on default accent color #0078D7 (RGB 0, 120, 215), which is slightly darkened for DWM
+
+	g_oldhslEnhancedAccentL = (g_hslDefaultAccent.l * 255) - g_oldhslAccentL;
 
 	return true;
 }

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -30,8 +30,8 @@ bool UpdateAccentColor()
 
 	if (accentColorChanges >= 2) {
 		g_oldhslAccentS = g_hslAccent.s;
-		if (g_oldhslAccentS <= 0.0666) {
-			g_oldhslAccentS = 0.0666;
+		if (g_oldhslAccentS <= 0.08) {
+			g_oldhslAccentS = 0.08;
 		}
 	}
 	else g_oldhslAccentS = 1;
@@ -81,7 +81,10 @@ bool UpdateAccentColor()
 
 	g_dwAccent = dwAccent;
 	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
-		g_hslAccent.s = 0.0667;
+		if (accentColorChanges == 1) {
+			g_hslAccent.s = 0.5;
+		}
+		else g_hslAccent.s = 0.0801;
 	}
 	else {
 		g_hslAccent.s = pow(double(rgb2hsl({
@@ -101,8 +104,8 @@ bool UpdateAccentColor()
 		(double)120 / 255,
 		(double)215 / 255 }).l);
 
-	if (g_hslAccent.s < 0.0666) {
-		g_hslAccent.s = 0.0666;
+	if (g_hslAccent.s < 0.08) {
+		g_hslAccent.s = 0.08;
 	}
 	if (accentColorChanges >= 2) {
 		if (g_hslAccent.s > 1) {
@@ -110,15 +113,18 @@ bool UpdateAccentColor()
 		}
 	}
 
-
-	g_hslAccent.l = ((double)(rgb2hsl({
-		(double)GetRValue(dwAccent) / 255,
-		(double)GetGValue(dwAccent) / 255,
-		(double)GetBValue(dwAccent) / 255 }).l) - (double)(rgb2hsl({
-		(double)0 / 255,
-		(double)110 / 255,
-		(double)199 / 255 }).l)) * -255.0; // based on default accent color #0078D7 (RGB 0, 120, 215), which is slightly darkened for DWM.
-
+	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent) && accentColorChanges == 1){
+		g_hslAccent.l = 0;
+	}
+	else {
+		g_hslAccent.l = ((double)(rgb2hsl({
+			(double)GetRValue(dwAccent) / 255,
+			(double)GetGValue(dwAccent) / 255,
+			(double)GetBValue(dwAccent) / 255 }).l) - (double)(rgb2hsl({
+			(double)0 / 255,
+			(double)110 / 255,
+			(double)199 / 255 }).l)) * -255.0; // based on default accent color #0078D7 (RGB 0, 120, 215), which is slightly darkened for DWM.
+	}
 	g_oldhslEnhancedAccentL = (g_hslDefaultAccent.l * 255) - (g_oldhslAccentL);
 
 	return true;

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -3,16 +3,15 @@
 #include <cmath>
 
 COLORREF g_dwAccent;
-int g_hslAccentH;
-double g_hslAccentS;
-double g_oldhslAccentS;
+//
+hsl_t g_hslAccent;
+hsl_t g_hslDefaultAccent;
+//
 double g_balance1hslAccentS;
 double g_balance2hslAccentS;
-double g_hslAccentL;
+//
 double g_oldhslAccentL;
-double g_defaulthslAccentH;
-double g_defaulthslAccentS;
-double g_defaulthslAccentL;
+double g_oldhslAccentS;
 
 bool UpdateAccentColor()
 {
@@ -29,7 +28,7 @@ bool UpdateAccentColor()
 	}
 
 	if (accentColorChanges >= 1) {
-		g_oldhslAccentS = g_hslAccentS;
+		g_oldhslAccentS = g_hslAccent.s;
 		if (g_oldhslAccentS <= 0.0666) {
 			g_oldhslAccentS = 0.0666;
 		}
@@ -37,16 +36,16 @@ bool UpdateAccentColor()
 	else g_oldhslAccentS = 1;
 
 	if (accentColorChanges >= 1) {
-		g_oldhslAccentL = g_hslAccentL;
+		g_oldhslAccentL = g_hslAccent.l;
 	}
 	else g_oldhslAccentL = 0;
 
 	g_dwAccent = dwAccent;
 	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
-		g_hslAccentH = 210.0;
+		g_hslAccent.h = 210.0;
 	}
 	else {
-		g_hslAccentH = rgb2hsl({
+		g_hslAccent.h = rgb2hsl({
 			(double)GetRValue(dwAccent) / 255,
 			(double)GetGValue(dwAccent) / 255,
 			(double)GetBValue(dwAccent) / 255 }).h;
@@ -61,36 +60,36 @@ bool UpdateAccentColor()
 
 	g_dwAccent = dwAccent;
 	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
-		g_hslAccentS = 0.0667;
+		g_hslAccent.s = 0.0667;
 	}
 	else {
-		g_hslAccentS = pow(double(rgb2hsl({
+		g_hslAccent.s = pow(double(rgb2hsl({
 			(double)GetRValue(dwAccent) / 254.999999999,
 			(double)GetGValue(dwAccent) / 254.999999999,
 			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.85));
 	}
 
 
-	g_balance1hslAccentS = g_hslAccentS;
-	g_balance2hslAccentS = (1 - g_hslAccentS);
+	g_balance1hslAccentS = g_hslAccent.s;
+	g_balance2hslAccentS = (1 - g_hslAccent.s);
 
-	g_defaulthslAccentH = 207;
-	g_defaulthslAccentS = 1;
-	g_defaulthslAccentL = (double)(rgb2hsl({
+	g_hslDefaultAccent.h = 207;
+	g_hslDefaultAccent.s = 1;
+	g_hslDefaultAccent.l = (double)(rgb2hsl({
 		(double)0 / 254.999999999,
 		(double)120 / 254.999999999,
 		(double)215 / 254.999999999 }).l);
 
-	if (g_hslAccentS < 0.0666) {
-		g_hslAccentS = 0.0666;
+	if (g_hslAccent.s < 0.0666) {
+		g_hslAccent.s = 0.0666;
 	}
 	if (accentColorChanges >= 1) {
-		if (g_hslAccentS > 1) {
-			g_hslAccentS = g_balance1hslAccentS + g_balance2hslAccentS;
+		if (g_hslAccent.s > 1) {
+			g_hslAccent.s = g_balance1hslAccentS + g_balance2hslAccentS;
 		}
 	}
 
-	g_hslAccentL = ((double)(rgb2hsl({
+	g_hslAccent.l = ((double)(rgb2hsl({
 		(double)GetRValue(dwAccent) / 254.999999999,
 		(double)GetGValue(dwAccent) / 254.999999999,
 		(double)GetBValue(dwAccent) / 254.999999999 }).l) - 

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -3,15 +3,12 @@
 #include <cmath>
 
 COLORREF g_dwAccent;
-//
 hsl_t g_hslAccent;
 hsl_t g_hslDefaultAccent;
-//
+double g_oldhslAccentS;
 double g_balance1hslAccentS;
 double g_balance2hslAccentS;
-//
 double g_oldhslAccentL;
-double g_oldhslAccentS;
 
 bool UpdateAccentColor()
 {
@@ -27,7 +24,7 @@ bool UpdateAccentColor()
 		return false;
 	}
 
-	if (accentColorChanges >= 1) {
+	if (accentColorChanges >= 2) {
 		g_oldhslAccentS = g_hslAccent.s;
 		if (g_oldhslAccentS <= 0.0666) {
 			g_oldhslAccentS = 0.0666;
@@ -35,7 +32,7 @@ bool UpdateAccentColor()
 	}
 	else g_oldhslAccentS = 1;
 
-	if (accentColorChanges >= 1) {
+	if (accentColorChanges >= 2) {
 		g_oldhslAccentL = g_hslAccent.l;
 	}
 	else g_oldhslAccentL = 0;
@@ -66,7 +63,7 @@ bool UpdateAccentColor()
 		g_hslAccent.s = pow(double(rgb2hsl({
 			(double)GetRValue(dwAccent) / 254.999999999,
 			(double)GetGValue(dwAccent) / 254.999999999,
-			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.85));
+			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.9));
 	}
 
 
@@ -76,27 +73,27 @@ bool UpdateAccentColor()
 	g_hslDefaultAccent.h = 207;
 	g_hslDefaultAccent.s = 1;
 	g_hslDefaultAccent.l = (double)(rgb2hsl({
-		(double)0 / 254.999999999,
-		(double)120 / 254.999999999,
-		(double)215 / 254.999999999 }).l);
+		(double)0 / 255,
+		(double)120 / 255,
+		(double)215 / 255 }).l);
 
 	if (g_hslAccent.s < 0.0666) {
 		g_hslAccent.s = 0.0666;
 	}
-	if (accentColorChanges >= 1) {
+	if (accentColorChanges >= 2) {
 		if (g_hslAccent.s > 1) {
 			g_hslAccent.s = g_balance1hslAccentS + g_balance2hslAccentS;
 		}
 	}
 
 	g_hslAccent.l = ((double)(rgb2hsl({
-		(double)GetRValue(dwAccent) / 254.999999999,
-		(double)GetGValue(dwAccent) / 254.999999999,
-		(double)GetBValue(dwAccent) / 254.999999999 }).l) - 
+		(double)GetRValue(dwAccent) / 255,
+		(double)GetGValue(dwAccent) / 255,
+		(double)GetBValue(dwAccent) / 255 }).l) - 
 					(double)(rgb2hsl({
-		(double)0 / 254.999999999,
-		(double)120 / 254.999999999,
-		(double)215 / 254.999999999 }).l)) * -255; // based on default accent color #0078D7 (RGB 0, 120, 215)
+		(double)0 / 255,
+		(double)120 / 255,
+		(double)215 / 255 }).l)) * -255; // based on default accent color #0078D7 (RGB 0, 120, 215)
 
 	return true;
 }

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -28,7 +28,6 @@ bool UpdateAccentColor()
 		return false;
 	}
 
-	g_dwAccent = dwAccent;
 	if (accentColorChanges >= 1) {
 		g_oldhslAccentS = g_hslAccentS;
 		if (g_oldhslAccentS <= 0.0666) {

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -35,10 +35,7 @@ bool UpdateAccentColor()
 			g_oldhslAccentS = 0.0666;
 		}
 	}
-	else g_oldhslAccentS = pow(double(rgb2hsl({
-			(double)GetRValue(dwAccent) / 254.999999999,
-			(double)GetGValue(dwAccent) / 254.999999999,
-			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.85));
+	else g_oldhslAccentS = 1;
 
 	if (accentColorChanges >= 1) {
 		g_oldhslAccentL = g_hslAccentL;

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -51,10 +51,13 @@ bool UpdateAccentColor()
 			(double)GetGValue(dwAccent) / 255,
 			(double)GetBValue(dwAccent) / 255 }).h;
 	}
-	if (g_hslAccent.h >= 0 && g_hslAccent.h < 120) {
+	if (g_hslAccent.h >= 0 && g_hslAccent.h < 125) {
 		g_hslLightAccentH = 60;
 	}
-	else if (g_hslAccent.h >= 120 && g_hslAccent.h < 240) {
+	else if (g_hslAccent.h >= 125 && g_hslAccent.h < 150) {
+		g_hslLightAccentH = 120;
+	}
+	else if (g_hslAccent.h >= 150 && g_hslAccent.h < 240) {
 		g_hslLightAccentH = 180;
 	}
 	else if (g_hslAccent.h >= 240 && g_hslAccent.h < 345) {
@@ -69,10 +72,10 @@ bool UpdateAccentColor()
 	else if (g_hslAccent.h >= 60 && g_hslAccent.h < 180) {
 		g_hslDarkAccentH = 120;
 	}
-	else if (g_hslAccent.h >= 180 && g_hslAccent.h < 285) {
+	else if (g_hslAccent.h >= 180 && g_hslAccent.h < 300) {
 		g_hslDarkAccentH = 240;
 	}
-	else if (g_hslAccent.h >= 285 && g_hslAccent.h < 360) {
+	else if (g_hslAccent.h >= 300 && g_hslAccent.h < 360) {
 		g_hslDarkAccentH = 360;
 	}
 
@@ -114,9 +117,9 @@ bool UpdateAccentColor()
 		(double)GetBValue(dwAccent) / 255 }).l) - (double)(rgb2hsl({
 		(double)0 / 255,
 		(double)110 / 255,
-		(double)199 / 255 }).l)) * -255.0; // based on default accent color #0078D7 (RGB 0, 120, 215), which is slightly darkened for DWM
+		(double)199 / 255 }).l)) * -255.0; // based on default accent color #0078D7 (RGB 0, 120, 215), which is slightly darkened for DWM.
 
-	g_oldhslEnhancedAccentL = (g_hslDefaultAccent.l * 255) - g_oldhslAccentL;
+	g_oldhslEnhancedAccentL = (g_hslDefaultAccent.l * 255) - (g_oldhslAccentL);
 
 	return true;
 }

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -2,15 +2,15 @@
 #include "ColorHelper.h"
 #include <cmath>
 
-COLORREF g_dwAccent;
-hsl_t g_hslAccent;
-hsl_t g_hslDefaultAccent;
-double g_oldhslAccentS;
-double g_balance1hslAccentS;
-double g_balance2hslAccentS;
-double g_oldhslAccentL;
-int g_hslLightAccentH;
-int g_hslDarkAccentH;
+COLORREF g_dwAccent{};
+hsl_t g_hslAccent{};
+hsl_t g_hslDefaultAccent{};
+double g_oldhslAccentS{};
+double g_balance1hslAccentS{};
+double g_balance2hslAccentS{};
+double g_oldhslAccentL{};
+int g_hslLightAccentH{};
+int g_hslDarkAccentH{};
 double g_hslEnhancedAccentL{};
 double g_oldhslEnhancedAccentL{};
 
@@ -113,8 +113,10 @@ bool UpdateAccentColor()
 		}
 	}
 
-	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent) && accentColorChanges == 1){
-		g_hslAccent.l = 0;
+	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)){
+		if (accentColorChanges == 1) {
+			g_hslAccent.l = 0.0;
+		}
 	}
 	else {
 		g_hslAccent.l = ((double)(rgb2hsl({

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -1,8 +1,18 @@
 #include "AccentColorHelper.h"
 #include "ColorHelper.h"
+#include <cmath>
 
 COLORREF g_dwAccent;
-int g_hsvAccentH;
+int g_hslAccentH;
+double g_hslAccentS;
+double g_oldhslAccentS;
+double g_balance1hslAccentS;
+double g_balance2hslAccentS;
+double g_hslAccentL;
+double g_oldhslAccentL;
+double g_defaulthslAccentH;
+double g_defaulthslAccentS;
+double g_defaulthslAccentL;
 
 bool UpdateAccentColor()
 {
@@ -18,11 +28,63 @@ bool UpdateAccentColor()
 		return false;
 	}
 
+	if (accentColorChanges >= 1) {
+		g_oldhslAccentS = g_hslAccentS;
+		if (g_oldhslAccentS <= 0.0666) {
+			g_oldhslAccentS = 0.0666;
+		}
+	}
+	else g_oldhslAccentS = 1;
+
 	g_dwAccent = dwAccent;
-	g_hsvAccentH = rgb2hsv({
-		(double) GetRValue(dwAccent) / 255,
-		(double) GetGValue(dwAccent) / 255,
-		(double) GetBValue(dwAccent) / 255 }).h;
+	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
+		g_hslAccentH = 210.0;
+	}
+	else {
+		g_hslAccentH = rgb2hsl({
+			(double)GetRValue(dwAccent) / 255,
+			(double)GetGValue(dwAccent) / 255,
+			(double)GetBValue(dwAccent) / 255 }).h;
+	}
+	/* if (g_hslAccentH < 0.0) {
+		g_hslAccentH += 360.0;
+	}
+
+	if (g_hslAccentH > 360.0) {
+		g_hslAccentH -= 360.0;
+	} */
+
+	g_dwAccent = dwAccent;
+	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
+		g_hslAccentS = 0.0667;
+	}
+	else {
+		g_hslAccentS = pow(double(rgb2hsl({
+			(double)GetRValue(dwAccent) / 254.999999999,
+			(double)GetGValue(dwAccent) / 254.999999999,
+			(double)GetBValue(dwAccent) / 254.999999999 }).s), double(0.85));
+	}
+
+
+	g_balance1hslAccentS = g_hslAccentS;
+	g_balance2hslAccentS = (1 - g_hslAccentS);
+
+	g_defaulthslAccentH = 207;
+	g_defaulthslAccentS = 1;
+
+	if (g_hslAccentS < 0.0666) {
+		g_hslAccentS = 0.0666;
+	}
+	if (accentColorChanges >= 1) {
+		if (g_hslAccentS > 1) {
+			g_hslAccentS = g_balance1hslAccentS + g_balance2hslAccentS;
+		}
+	}
+
+	g_hslAccentL = (double(rgb2hsl({
+		(double)GetRValue(dwAccent) / 254.999999999,
+		(double)GetGValue(dwAccent) / 254.999999999,
+		(double)GetBValue(dwAccent) / 254.999999999 }).l) - (double)0.4215686) * 255; // based on default accent color #0078D7 (RGB 0, 120, 215)
 
 	return true;
 }

--- a/AccentColorizer/AccentColorHelper.cpp
+++ b/AccentColorizer/AccentColorHelper.cpp
@@ -42,6 +42,7 @@ bool UpdateAccentColor()
 	else g_oldhslAccentL = 0;
 
 	g_dwAccent = dwAccent;
+
 	if ((double)GetRValue(dwAccent) == (double)GetGValue(dwAccent) && (double)GetGValue(dwAccent) == (double)GetBValue(dwAccent)) {
 		g_hslAccent.h = 210.0;
 	}
@@ -107,7 +108,7 @@ bool UpdateAccentColor()
 	if (g_hslAccent.s < 0.08) {
 		g_hslAccent.s = 0.08;
 	}
-	if (accentColorChanges >= 2) {
+	if (accentColorChanges >= 1) {
 		if (g_hslAccent.s > 1) {
 			g_hslAccent.s = g_balance1hslAccentS + g_balance2hslAccentS;
 		}
@@ -127,6 +128,7 @@ bool UpdateAccentColor()
 			(double)110 / 255,
 			(double)199 / 255 }).l)) * -255.0; // based on default accent color #0078D7 (RGB 0, 120, 215), which is slightly darkened for DWM.
 	}
+	g_hslAccent.l = g_hslAccent.l;
 	g_oldhslEnhancedAccentL = (g_hslDefaultAccent.l * 255) - (g_oldhslAccentL);
 
 	return true;

--- a/AccentColorizer/AccentColorHelper.h
+++ b/AccentColorizer/AccentColorHelper.h
@@ -9,6 +9,10 @@ extern double g_oldhslAccentS;
 extern double g_balance1hslAccentS;
 extern double g_balance2hslAccentS;
 extern double g_oldhslAccentL;
+extern int g_hslLightAccentH;
+extern int g_hslDarkAccentH;
+extern double g_hslEnhancedAccentL;
+extern double g_oldhslEnhancedAccentL;
 extern int accentColorChanges;
 
 bool UpdateAccentColor();

--- a/AccentColorizer/AccentColorHelper.h
+++ b/AccentColorizer/AccentColorHelper.h
@@ -3,16 +3,12 @@
 #include "ColorHelper.h"
 
 extern COLORREF g_dwAccent;
-//
 extern hsl_t g_hslAccent;
 extern hsl_t g_hslDefaultAccent;
-//
+extern double g_oldhslAccentS;
 extern double g_balance1hslAccentS;
 extern double g_balance2hslAccentS;
-//
 extern double g_oldhslAccentL;
-extern double g_oldhslAccentS;
-//
 extern int accentColorChanges;
 
 bool UpdateAccentColor();

--- a/AccentColorizer/AccentColorHelper.h
+++ b/AccentColorizer/AccentColorHelper.h
@@ -2,6 +2,16 @@
 #include "framework.h"
 
 extern COLORREF g_dwAccent;
-extern int g_hsvAccentH;
+extern int g_hslAccentH;
+extern double g_hslAccentS;
+extern double g_oldhslAccentS;
+extern double g_balance1hslAccentS;
+extern double g_balance2hslAccentS;
+extern double g_hslAccentL;
+extern double g_oldhslAccentL;
+extern double g_defaulthslAccentH;
+extern double g_defaulthslAccentS;
+extern double g_defaulthslAccentL;
+extern int accentColorChanges;
 
 bool UpdateAccentColor();

--- a/AccentColorizer/AccentColorHelper.h
+++ b/AccentColorizer/AccentColorHelper.h
@@ -1,17 +1,18 @@
 #pragma once
 #include "framework.h"
+#include "ColorHelper.h"
 
 extern COLORREF g_dwAccent;
-extern int g_hslAccentH;
-extern double g_hslAccentS;
-extern double g_oldhslAccentS;
+//
+extern hsl_t g_hslAccent;
+extern hsl_t g_hslDefaultAccent;
+//
 extern double g_balance1hslAccentS;
 extern double g_balance2hslAccentS;
-extern double g_hslAccentL;
+//
 extern double g_oldhslAccentL;
-extern double g_defaulthslAccentH;
-extern double g_defaulthslAccentS;
-extern double g_defaulthslAccentL;
+extern double g_oldhslAccentS;
+//
 extern int accentColorChanges;
 
 bool UpdateAccentColor();

--- a/AccentColorizer/AccentColorizer.vcxproj
+++ b/AccentColorizer/AccentColorizer.vcxproj
@@ -38,40 +38,40 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -222,6 +222,7 @@
     <ClInclude Include="ColorHelper.h" />
     <ClInclude Include="SettingsHelper.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="StyleColorHelper.h" />
     <ClInclude Include="StyleModifier.h" />
     <ClInclude Include="SysColorsModifier.h" />
     <ClInclude Include="framework.h" />
@@ -233,6 +234,7 @@
     <ClCompile Include="BitmapHelper.cpp" />
     <ClCompile Include="ColorHelper.cpp" />
     <ClCompile Include="SettingsHelper.cpp" />
+    <ClCompile Include="StyleColorHelper.cpp" />
     <ClCompile Include="StyleModifier.cpp" />
     <ClCompile Include="SysColorsModifier.cpp" />
     <ClCompile Include="SystemHelper.cpp" />

--- a/AccentColorizer/AccentColorizer.vcxproj
+++ b/AccentColorizer/AccentColorizer.vcxproj
@@ -101,25 +101,31 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)-$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)-$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)Release\</OutDir>
     <IntDir>Release\</IntDir>
+    <TargetName>$(ProjectName)-$(PlatformTarget)-Static</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)-$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)-$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\Release\</OutDir>
     <IntDir>$(Platform)\Release\</IntDir>
+    <TargetName>$(ProjectName)-$(PlatformTarget)-Static</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -165,7 +171,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OutputFile>$(OutDir)$(TargetName)-Static$(TargetExt)</OutputFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -195,7 +200,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OutputFile>$(OutDir)$(TargetName)-x64$(TargetExt)</OutputFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|x64'">
@@ -213,7 +217,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OutputFile>$(OutDir)$(TargetName)-Static-x64$(TargetExt)</OutputFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/AccentColorizer/AccentColorizer.vcxproj.filters
+++ b/AccentColorizer/AccentColorizer.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClCompile Include="SystemHelper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="StyleColorHelper.cpp">
+      <Filter>Header Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AccentColorHelper.h">
@@ -52,6 +55,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SystemHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="StyleColorHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AccentColorizer/BitmapHelper.cpp
+++ b/AccentColorizer/BitmapHelper.cpp
@@ -1,46 +1,50 @@
 #include "BitmapHelper.h"
 
+vector <HBITMAP> hBitmapList;
+
 bool IterateBitmap(HBITMAP hbm, BitmapPixelHandler handler)
 {
-    BITMAP bm;
-    GetObject(hbm, sizeof(bm), &bm);
+    if (count(hBitmapList.begin(), hBitmapList.end(), hbm) < 1) {
+        hBitmapList.push_back(hbm);
+        BITMAP bm;
+        GetObject(hbm, sizeof(bm), &bm);
 
-    if (!hbm || bm.bmBitsPixel != 32)
-    {
-        return false;
-    }
-
-    BYTE* pBits = new BYTE[bm.bmWidth * bm.bmHeight * 4];
-    GetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
-
-    BYTE* pPixel;
-    int x, y;
-    int r, g, b, a;
-
-    for (y = 0; y < bm.bmHeight; y++)
-    {
-        pPixel = pBits + bm.bmWidth * 4 * y;
-
-        for (x = 0; x < bm.bmWidth; x++)
+        if (!hbm || bm.bmBitsPixel != 32)
         {
-            r = pPixel[2] & 0xFFFFFF;
-            g = pPixel[1] & 0xFFFFFF;
-            b = pPixel[0] & 0xFFFFFF;
-            a = pPixel[3] & 0xFFFFFF;
-
-            handler(r, g, b, a);
-
-            pPixel[2] = r;
-            pPixel[1] = g;
-            pPixel[0] = b;
-            pPixel[3] = a;
-
-            pPixel += 4;
+            return false;
         }
+
+        BYTE* pBits = new BYTE[bm.bmWidth * bm.bmHeight * 4];
+        GetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
+
+        BYTE* pPixel;
+        int x, y;
+        int r, g, b, a;
+
+        for (y = 0; y < bm.bmHeight; y++)
+        {
+            pPixel = pBits + bm.bmWidth * 4 * y;
+
+            for (x = 0; x < bm.bmWidth; x++)
+            {
+                r = pPixel[2] & 0xFFFFFF;
+                g = pPixel[1] & 0xFFFFFF;
+                b = pPixel[0] & 0xFFFFFF;
+                a = pPixel[3] & 0xFFFFFF;
+
+                handler(r, g, b, a);
+
+                pPixel[2] = r;
+                pPixel[1] = g;
+                pPixel[0] = b;
+                pPixel[3] = a;
+
+                pPixel += 4;
+            }
+        }
+
+        SetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
+        delete[] pBits;
     }
-
-    SetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
-
-    delete[] pBits;
     return true;
 }

--- a/AccentColorizer/BitmapHelper.cpp
+++ b/AccentColorizer/BitmapHelper.cpp
@@ -1,15 +1,7 @@
 #include "BitmapHelper.h"
 
-std::set<HBITMAP> handledBitmaps;
-
 bool IterateBitmap(HBITMAP hbm, BitmapPixelHandler handler)
 {
-    if (handledBitmaps.find(hbm) != handledBitmaps.end())
-    {
-        return true;
-    }
-    handledBitmaps.emplace(hbm);
-
     BITMAP bm;
     GetObject(hbm, sizeof(bm), &bm);
 

--- a/AccentColorizer/BitmapHelper.cpp
+++ b/AccentColorizer/BitmapHelper.cpp
@@ -1,50 +1,54 @@
 #include "BitmapHelper.h"
 
-vector <HBITMAP> hBitmapList;
+std::set<HBITMAP> handledBitmaps;
 
 bool IterateBitmap(HBITMAP hbm, BitmapPixelHandler handler)
 {
-    if (count(hBitmapList.begin(), hBitmapList.end(), hbm) < 1) {
-        hBitmapList.push_back(hbm);
-        BITMAP bm;
-        GetObject(hbm, sizeof(bm), &bm);
-
-        if (!hbm || bm.bmBitsPixel != 32)
-        {
-            return false;
-        }
-
-        BYTE* pBits = new BYTE[bm.bmWidth * bm.bmHeight * 4];
-        GetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
-
-        BYTE* pPixel;
-        int x, y;
-        int r, g, b, a;
-
-        for (y = 0; y < bm.bmHeight; y++)
-        {
-            pPixel = pBits + bm.bmWidth * 4 * y;
-
-            for (x = 0; x < bm.bmWidth; x++)
-            {
-                r = pPixel[2] & 0xFFFFFF;
-                g = pPixel[1] & 0xFFFFFF;
-                b = pPixel[0] & 0xFFFFFF;
-                a = pPixel[3] & 0xFFFFFF;
-
-                handler(r, g, b, a);
-
-                pPixel[2] = r;
-                pPixel[1] = g;
-                pPixel[0] = b;
-                pPixel[3] = a;
-
-                pPixel += 4;
-            }
-        }
-
-        SetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
-        delete[] pBits;
+    if (handledBitmaps.find(hbm) != handledBitmaps.end())
+    {
+        return true;
     }
+    handledBitmaps.emplace(hbm);
+
+    BITMAP bm;
+    GetObject(hbm, sizeof(bm), &bm);
+
+    if (!hbm || bm.bmBitsPixel != 32)
+    {
+        return false;
+    }
+
+    BYTE* pBits = new BYTE[bm.bmWidth * bm.bmHeight * 4];
+    GetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
+
+    BYTE* pPixel;
+    int x, y;
+    int r, g, b, a;
+
+    for (y = 0; y < bm.bmHeight; y++)
+    {
+        pPixel = pBits + bm.bmWidth * 4 * y;
+
+        for (x = 0; x < bm.bmWidth; x++)
+        {
+            r = pPixel[2] & 0xFFFFFF;
+            g = pPixel[1] & 0xFFFFFF;
+            b = pPixel[0] & 0xFFFFFF;
+            a = pPixel[3] & 0xFFFFFF;
+
+            handler(r, g, b, a);
+
+            pPixel[2] = r;
+            pPixel[1] = g;
+            pPixel[0] = b;
+            pPixel[3] = a;
+
+            pPixel += 4;
+        }
+    }
+
+    SetBitmapBits(hbm, bm.bmWidth * bm.bmHeight * 4, pBits);
+    delete[] pBits;
+
     return true;
 }

--- a/AccentColorizer/BitmapHelper.h
+++ b/AccentColorizer/BitmapHelper.h
@@ -1,5 +1,10 @@
 #pragma once
 #include "framework.h"
+#include <iostream>
+#include <vector>
+
+using namespace std;
+extern vector <HBITMAP> hBitmapList;
 
 typedef void (*BitmapPixelHandler)(int& r, int& g, int& b, int& a);
 

--- a/AccentColorizer/BitmapHelper.h
+++ b/AccentColorizer/BitmapHelper.h
@@ -1,10 +1,10 @@
 #pragma once
+
 #include "framework.h"
 #include <iostream>
-#include <vector>
+#include <set>
 
-using namespace std;
-extern vector <HBITMAP> hBitmapList;
+extern std::set<HBITMAP> handledBitmaps;
 
 typedef void (*BitmapPixelHandler)(int& r, int& g, int& b, int& a);
 

--- a/AccentColorizer/BitmapHelper.h
+++ b/AccentColorizer/BitmapHelper.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "framework.h"
 #include <set>
 

--- a/AccentColorizer/BitmapHelper.h
+++ b/AccentColorizer/BitmapHelper.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "framework.h"
-#include <iostream>
 #include <set>
 
 extern std::set<HBITMAP> handledBitmaps;

--- a/AccentColorizer/ColorHelper.cpp
+++ b/AccentColorizer/ColorHelper.cpp
@@ -10,7 +10,7 @@ DWORD rgb2bgr(COLORREF color)
 
 hsl_t rgb2hsl(rgb_t in)
 {
-	hsl_t       out;
+	hsl_t       out{};
 	double      min, max, sigma, delta;
 
 	min = in.r < in.g ? in.r : in.g;
@@ -64,8 +64,8 @@ hsl_t rgb2hsl(rgb_t in)
 
 rgb_t hsl2rgb(hsl_t in)
 {
-	double      ot, tt, ht, rt, gt, bt; // temporary values one, two, hue, red, green, blue
-	rgb_t       out;
+	double      ot{}, tt, ht, rt, gt, bt; // temporary values one, two, hue, red, green, blue
+	rgb_t       out{};
 
 	/*if (in.s <= 0.0) {       // "<" is useless, just shuts up warnings
 		out.r = in.l;
@@ -73,7 +73,10 @@ rgb_t hsl2rgb(hsl_t in)
 		out.b = in.l;
 		return out;
 	}*/ // this was making saturation always return 0
-	if (in.l < 0.5)
+	if (in.l == 0) {
+		ot = 0;
+	}
+	if (in.l < 0.5 && in.l > 0)
 	{
 		ot = in.l * (1.0 + in.s);
 	}

--- a/AccentColorizer/ColorHelper.cpp
+++ b/AccentColorizer/ColorHelper.cpp
@@ -41,7 +41,8 @@ hsl_t rgb2hsl(rgb_t in)
 		} */
 	}
 	else {
-		// if max is 0, then r = g = b = 0              
+		// if max is 0, then r = g = b = 0   
+		out.h = 210.0;
 		out.s = 0.0;
 		return out;
 	}

--- a/AccentColorizer/ColorHelper.cpp
+++ b/AccentColorizer/ColorHelper.cpp
@@ -73,9 +73,6 @@ rgb_t hsl2rgb(hsl_t in)
 		out.b = in.l;
 		return out;
 	}*/ // this was making saturation always return 0
-	if (in.l == 0) {
-		ot = 0;
-	}
 	if (in.l < 0.5 && in.l > 0)
 	{
 		ot = in.l * (1.0 + in.s);

--- a/AccentColorizer/ColorHelper.cpp
+++ b/AccentColorizer/ColorHelper.cpp
@@ -46,12 +46,12 @@ hsl_t rgb2hsl(rgb_t in)
 		return out;
 	}
 	if (in.r >= max)                           // ">" is useless, just keeps compiler happy
-		out.h = (((in.g - in.b) / delta) * 60.0);        // between yellow & magenta
+		out.h = (((in.g - in.b) / 6) / delta) * 360.0;        // between yellow & magenta
 	else
 		if (in.g >= max)
-			out.h = ((2.0 + (in.b - in.r) / delta) * 60.0);  // between cyan & yellow
+			out.h = ((1.0 / 3.0) + ((in.b - in.r) / 6) / delta) * 360.0;  // between cyan & yellow
 		else
-			out.h = ((4.0 + (in.r - in.g) / delta) * 60.0);  // between magenta & cyan
+			out.h = ((2.0 / 3.0) + ((in.r - in.g) / 6) / delta) * 360.0;  // between magenta & cyan
 
 	if (out.h < 0.0)
 		out.h += 360.0;
@@ -64,7 +64,7 @@ hsl_t rgb2hsl(rgb_t in)
 
 rgb_t hsl2rgb(hsl_t in)
 {
-	double      ot{}, tt, ht, rt, gt, bt; // temporary values one, two, hue, red, green, blue
+	double      ot{}, tt{}, ht{}, rt{}, gt{}, bt{}; // temporary values one, two, hue, red, green, blue
 	rgb_t       out{};
 
 	/*if (in.s <= 0.0) {       // "<" is useless, just shuts up warnings
@@ -73,7 +73,7 @@ rgb_t hsl2rgb(hsl_t in)
 		out.b = in.l;
 		return out;
 	}*/ // this was making saturation always return 0
-	if (in.l < 0.5 && in.l > 0)
+	if (in.l < 0.5)
 	{
 		ot = in.l * (1.0 + in.s);
 	}
@@ -82,7 +82,7 @@ rgb_t hsl2rgb(hsl_t in)
 		ot = in.l + in.s - (in.l * in.s);
 	}
 	tt = (2 * in.l) - ot;
-	ht = in.h /= 360.0;
+	ht = in.h / 360.0;
 	if (ht > 0.6666667) {
 		rt = ht - (0.6666667);
 	}

--- a/AccentColorizer/ColorHelper.h
+++ b/AccentColorizer/ColorHelper.h
@@ -8,10 +8,10 @@ struct rgb_t
 	double r, g, b;
 };
 
-struct hsv_t
+struct hsl_t
 {
-	double h, s, v;
+	double h, s, l;
 };
 
-hsv_t rgb2hsv(rgb_t in);
-rgb_t hsv2rgb(hsv_t in);
+hsl_t rgb2hsl(rgb_t in);
+rgb_t hsl2rgb(hsl_t in);

--- a/AccentColorizer/ColorHelper.h
+++ b/AccentColorizer/ColorHelper.h
@@ -5,12 +5,12 @@ DWORD rgb2bgr(COLORREF rgb);
 
 struct rgb_t
 {
-	double r, g, b;
+	double r{}, g{}, b{};
 };
 
 struct hsl_t
 {
-	double h, s, l;
+	double h{}, s{}, l{};
 };
 
 hsl_t rgb2hsl(rgb_t in);

--- a/AccentColorizer/SettingsHelper.cpp
+++ b/AccentColorizer/SettingsHelper.cpp
@@ -36,7 +36,7 @@ GetRegistryOptionStatus(LPCWSTR key, LPCWSTR value)
 
     RegCloseKey(hKey);
 
-    return ERROR_SUCCESS == nError 
+    return ERROR_SUCCESS == nError
         ? REGISTRY_OPTION_ENABLED
         : REGISTRY_OPTION_DISABLED;
 }

--- a/AccentColorizer/SettingsHelper.cpp
+++ b/AccentColorizer/SettingsHelper.cpp
@@ -3,7 +3,17 @@
 
 #include <VersionHelpers.h>
 
-bool IsRegistryValueEnabled(LPCWSTR key, LPCWSTR value)
+#define DEFAULT_PROGRESS_BAR_COLORIZATION FALSE
+
+enum REGISTRY_OPTION_STATUS
+{
+    REGISTRY_OPTION_ENABLED,
+    REGISTRY_OPTION_DISABLED,
+    REGISTRY_OPTION_NOT_SET
+};
+
+REGISTRY_OPTION_STATUS
+GetRegistryOptionStatus(LPCWSTR key, LPCWSTR value)
 {
     HKEY hKey;
     RegOpenKeyEx(
@@ -13,7 +23,7 @@ bool IsRegistryValueEnabled(LPCWSTR key, LPCWSTR value)
 
     if (!hKey)
     {
-        return false;
+        return REGISTRY_OPTION_NOT_SET;
     }
 
     DWORD dwBufferSize(sizeof(DWORD));
@@ -26,7 +36,9 @@ bool IsRegistryValueEnabled(LPCWSTR key, LPCWSTR value)
 
     RegCloseKey(hKey);
 
-    return ERROR_SUCCESS == nError ? nResult : false;
+    return ERROR_SUCCESS == nError 
+        ? REGISTRY_OPTION_ENABLED
+        : REGISTRY_OPTION_DISABLED;
 }
 
 bool IsMenuColorizationEnabled()
@@ -42,5 +54,9 @@ bool IsMenuColorizationEnabled()
 
 bool IsProgressBarColorizationEnabled()
 {
-    return IsRegistryValueEnabled(L"SOFTWARE\\AccentColorizer", L"ColorizeProgressBar");
+    REGISTRY_OPTION_STATUS status = GetRegistryOptionStatus(L"SOFTWARE\\AccentColorizer", L"ColorizeProgressBar");
+    if (status == REGISTRY_OPTION_NOT_SET) {
+        return DEFAULT_PROGRESS_BAR_COLORIZATION;
+    }
+    return status == REGISTRY_OPTION_ENABLED;
 }

--- a/AccentColorizer/StyleColorHelper.cpp
+++ b/AccentColorizer/StyleColorHelper.cpp
@@ -1,0 +1,9 @@
+#include "StyleColorHelper.h"
+
+
+bool IterateColor(COLORREF color, ColorHandler handler) // dummy code
+{
+    int r, g, b;
+    GetTextColor;
+    return true;
+}

--- a/AccentColorizer/StyleColorHelper.cpp
+++ b/AccentColorizer/StyleColorHelper.cpp
@@ -1,4 +1,4 @@
-#include "StyleColorHelper.h"
+/* #include "StyleColorHelper.h"
 
 
 bool IterateColor(COLORREF color, ColorHandler handler) // dummy code
@@ -6,4 +6,4 @@ bool IterateColor(COLORREF color, ColorHandler handler) // dummy code
     int r, g, b;
     GetTextColor;
     return true;
-}
+} */

--- a/AccentColorizer/StyleColorHelper.h
+++ b/AccentColorizer/StyleColorHelper.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "framework.h"
+
+typedef void (*ColorHandler)(int& r, int& g, int& b); // dummy code
+
+bool IterateColor(COLORREF color, ColorHandler handler); // dummy code

--- a/AccentColorizer/StyleColorHelper.h
+++ b/AccentColorizer/StyleColorHelper.h
@@ -1,6 +1,7 @@
-#pragma once
+/* #pragma once
 #include "framework.h"
 
 typedef void (*ColorHandler)(int& r, int& g, int& b); // dummy code
 
 bool IterateColor(COLORREF color, ColorHandler handler); // dummy code
+*/

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -94,12 +94,12 @@ bool ModifyStyle(int iPartId, int iStateId, int iPropId)
 	return IterateBitmap(hBitmap, StandardBitmapPixelHandler);
 }
 
-bool ModifyColorStyle(int iPartId, int iStateId, int iPropId) // dummy code
+/* bool ModifyColorStyle(int iPartId, int iStateId, int iPropId) // dummy code
 {
 	COLORREF hColor;
 	GetThemeColor(hTheme, iPartId, iStateId, iPropId, &hColor);
 	return IterateColor(hColor, StandardColorHandler);
-}
+} */
 
 ///
 /// At first glance, such refactoring looks useless,
@@ -112,9 +112,9 @@ void ModifyStyles()
 	int i, j, k;
 	//
 
-	SetCurrentTheme(L"CommandModule"); // dummy code
+	/* SetCurrentTheme(L"CommandModule"); // dummy code
 	//
-	ModifyColorStyle(3, 2, TMT_TEXTCOLOR);
+	ModifyColorStyle(3, 2, TMT_TEXTCOLOR); */
 
 	SetCurrentTheme(VSCLASS_BUTTON);
 	//

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -79,6 +79,11 @@ void ModifyStyles()
 	int i, j, k;
 	//
 
+	SetCurrentTheme(L"DirectUI::Button"); // Explorer / Legacy Shell Date Picker
+	//
+	ModifyStyle(1, 0, 0);
+
+
 	SetCurrentTheme(L"CommandModule"); // dummy code
 	//
 	ModifyColorStyle(3, 2, TMT_TEXTCOLOR);

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -36,7 +36,7 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 		}
 		else hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
 	}
-	else hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l) * hslVal.s;
+	else hslVal.l = hslVal.l - ((g_oldhslAccentL - g_hslAccent.l) * hslVal.s);
 
 	if (hslVal.l > g_hslEnhancedAccentHL) {
 		hslVal.h = g_hslAccent.h + 0.5 * ((g_hslLightAccentH - g_hslAccent.h) * ((hslVal.l - g_hslEnhancedAccentHL) / (255.0 - g_hslEnhancedAccentHL)));
@@ -128,6 +128,18 @@ void ModifyStyles()
 		ModifyStyle(BP_COMMANDLINKGLYPH, 0, j);
 	}
 
+	SetCurrentTheme(L"DarkMode_Explorer::Button");
+	//
+	ModifyStyle(BP_PUSHBUTTON, 0, 0);
+	ModifyStyle(BP_COMMANDLINK, 0, 0);
+	for (j = 1; j <= 7; j++)
+	{
+		ModifyStyle(BP_RADIOBUTTON, 0, j);
+		ModifyStyle(BP_CHECKBOX, 0, j);
+		ModifyStyle(BP_GROUPBOX, 0, j);
+		ModifyStyle(BP_COMMANDLINKGLYPH, 0, j);
+	}
+
 
 	SetCurrentTheme(VSCLASS_COMBOBOX);
 	//
@@ -139,8 +151,28 @@ void ModifyStyles()
 		}
 	}
 
+	SetCurrentTheme(L"DarkMode_CFD::Combobox");
+	//
+	for (i = CP_DROPDOWNBUTTON; i <= CP_DROPDOWNBUTTONLEFT; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+		}
+	}
+
 
 	SetCurrentTheme(VSCLASS_EDIT);
+	//
+	for (i = EP_EDITBORDER_NOSCROLL; i <= EP_EDITBORDER_HVSCROLL; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+		}
+	}
+
+	SetCurrentTheme(L"DarkMode_Explorer::Edit");
 	//
 	for (i = EP_EDITBORDER_NOSCROLL; i <= EP_EDITBORDER_HVSCROLL; i++)
 	{
@@ -1042,6 +1074,13 @@ void ModifyStyles()
 
 
 	SetCurrentTheme(L"ScrollBar");
+	//
+	for (i = 1; i <= 10; i++)
+	{
+		ModifyStyle(i, 0, 0);
+	}
+
+	SetCurrentTheme(L"DarkMode_Explorer::ScrollBar");
 	//
 	for (i = 1; i <= 10; i++)
 	{

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -948,18 +948,17 @@ void ModifyStyles()
 				ModifyStyle(i, 1, k);
 			}
 		}
-	}
 
-	SetCurrentTheme(L"Indeterminate::Progress");
-	//
-	for (i = 3; i <= 10; i++)
-	{
-		for (k = 1; k <= 7; k++)
+		SetCurrentTheme(L"Indeterminate::Progress");
+		//
+		for (i = 3; i <= 10; i++)
 		{
-			ModifyStyle(i, 1, k);
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, 1, k);
+			}
 		}
 	}
-
 
 	SetCurrentTheme(L"AB::AddressBand");
 	//

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -8,7 +8,7 @@
 
 bool g_bColorizeMenus;
 bool g_bColorizeProgressBar;
-double g_hslEnhancedAccentHL;
+double g_hslEnhancedAccentHL{};
 
 HTHEME hTheme = nullptr;
 
@@ -948,18 +948,18 @@ void ModifyStyles()
 				ModifyStyle(i, 1, k);
 			}
 		}
+	}
 
-
-		SetCurrentTheme(L"Indeterminate::Progress");
-		//
-		for (i = 3; i <= 10; i++)
+	SetCurrentTheme(L"Indeterminate::Progress");
+	//
+	for (i = 3; i <= 10; i++)
+	{
+		for (k = 1; k <= 7; k++)
 		{
-			for (k = 1; k <= 7; k++)
-			{
-				ModifyStyle(i, 1, k);
-			}
+			ModifyStyle(i, 1, k);
 		}
 	}
+
 
 	SetCurrentTheme(L"AB::AddressBand");
 	//

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -8,7 +8,7 @@
 
 bool g_bColorizeMenus;
 bool g_bColorizeProgressBar;
-double brightnessMultiplier{};
+double g_hslEnhancedAccentHL;
 
 HTHEME hTheme = nullptr;
 
@@ -22,19 +22,25 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 	rgbVal.b = rgbVal.b / (a / 255.0);
 	hsl_t hslVal = rgb2hsl(rgbVal);
 
-	if (accentColorChanges == 1) {
-		hslVal.l = hslVal.l + (18.0 * hslVal.s);
-	}
+	g_hslEnhancedAccentHL = (g_hslDefaultAccent.l * 255) - g_hslAccent.l;
 
 	hslVal.h = g_hslDefaultAccent.h;
 	if (hslVal.l >= 128 && hslVal.l <= 254) {
 		hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s / ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
 	}
 	else hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s;
-	
-	hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l - (3.6 * (g_hslDefaultAccent.l - (g_hslAccent.l / 255)))) * (1 - (hslVal.l / 255.0)) * hslVal.s;
 
-	hslVal.h = g_hslAccent.h;
+	if (hslVal.l > (g_oldhslEnhancedAccentL)) {
+		hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL + (0.008 * ((hslVal.l - g_oldhslEnhancedAccentL) * g_oldhslAccentL))) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
+	}
+	else hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL) * hslVal.s);
+
+	if (hslVal.l > g_hslEnhancedAccentHL) {
+		hslVal.h = g_hslAccent.h + 0.55 * ((g_hslLightAccentH - g_hslAccent.h) * ((hslVal.l - g_hslEnhancedAccentHL) / (255.0 - g_hslEnhancedAccentHL)));
+	}
+	else if (hslVal.l <= g_hslEnhancedAccentHL) {
+		hslVal.h = g_hslAccent.h + 0.55 * ((g_hslDarkAccentH - g_hslAccent.h) * ((g_hslEnhancedAccentHL - hslVal.l) / g_hslEnhancedAccentHL));
+	}
 
 	if (hslVal.l >= 128 && hslVal.l <= 254) {
 		hslVal.s = (double)hslVal.s * (double)g_hslAccent.s * ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
@@ -804,154 +810,150 @@ void ModifyStyles()
 		}
 	}
 
-	if (g_bColorizeMenus)
+	SetCurrentTheme(L"Menu");
+	//
+	for (k = 1; k <= 7; k++)
 	{
-		SetCurrentTheme(L"Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(16, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-			ModifyStyle(13, 0, k);
-			ModifyStyle(12, 0, k);
-			ModifyStyle(10, 0, k);
-			ModifyStyle(9, 0, k);
-			ModifyStyle(8, 0, k);
-			ModifyStyle(7, 0, k);
-		}
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(16, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(12, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+		ModifyStyle(8, 0, k);
+		ModifyStyle(7, 0, k);
+	}
 
-		// Menu Checkbox
-		for (j = 0; j <= 7; j++)
+	// Menu Checkbox
+	for (j = 0; j <= 7; j++)
+	{
+		for (k = 0; k <= 7; k++)
 		{
-			for (k = 0; k <= 7; k++)
-			{
-				ModifyStyle(11, j, k);
-			}
-		}
-
-		SetCurrentTheme(L"DarkMode::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(16, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-			ModifyStyle(13, 0, k);
-			ModifyStyle(12, 0, k);
-			ModifyStyle(10, 0, k);
-			ModifyStyle(9, 0, k);
-			ModifyStyle(8, 0, k);
-			ModifyStyle(7, 0, k);
-		}
-
-		// Menu Checkbox
-		for (j = 0; j <= 7; j++)
-		{
-			for (k = 0; k <= 7; k++)
-			{
-				ModifyStyle(11, j, k);
-			}
-		}
-
-		SetCurrentTheme(L"ImmersiveStart::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-		}
-
-		SetCurrentTheme(L"ImmersiveStartDark::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-		}
-
-		SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-		}
-
-		SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-		}
-
-		SetCurrentTheme(L"Communications::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-			ModifyStyle(13, 0, k);
-			ModifyStyle(10, 0, k);
-			ModifyStyle(9, 0, k);
-		}
-
-		SetCurrentTheme(L"Media::Menu");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(27, 0, k);
-			ModifyStyle(26, 0, k);
-			ModifyStyle(15, 0, k);
-			ModifyStyle(14, 0, k);
-			ModifyStyle(13, 0, k);
-			ModifyStyle(10, 0, k);
-			ModifyStyle(9, 0, k);
+			ModifyStyle(11, j, k);
 		}
 	}
 
-	if (g_bColorizeProgressBar) {
-		SetCurrentTheme(L"Progress");
-		//
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(5, 4, k);
-			ModifyStyle(6, 4, k);
-		}
-		for (i = 3; i <= 12; i++)
-		{
-			for (k = 1; k <= 7; k++)
-			{
-				ModifyStyle(i, 1, k);
-			}
-		}
+	SetCurrentTheme(L"DarkMode::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(16, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(12, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+		ModifyStyle(8, 0, k);
+		ModifyStyle(7, 0, k);
+	}
 
-
-		SetCurrentTheme(L"Indeterminate::Progress");
-		//
-		for (i = 3; i <= 10; i++)
+	// Menu Checkbox
+	for (j = 0; j <= 7; j++)
+	{
+		for (k = 0; k <= 7; k++)
 		{
-			for (k = 1; k <= 7; k++)
-			{
-				ModifyStyle(i, 1, k);
-			}
+			ModifyStyle(11, j, k);
 		}
 	}
+
+	SetCurrentTheme(L"ImmersiveStart::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"ImmersiveStartDark::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"Communications::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+	}
+
+	SetCurrentTheme(L"Media::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+	}
+
+	SetCurrentTheme(L"Progress");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(5, 4, k);
+		ModifyStyle(6, 4, k);
+	}
+	for (i = 3; i <= 12; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
+	}
+
+
+	SetCurrentTheme(L"Indeterminate::Progress");
+	//
+	for (i = 3; i <= 10; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
+	}
+
 
 	SetCurrentTheme(L"AB::AddressBand");
 	//

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -17,13 +17,13 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 	rgb_t rgbVal = { r, g, b };
 	hsl_t hslVal = rgb2hsl(rgbVal);
 
-	hslVal.h = g_defaulthslAccentH;
-	hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
+	hslVal.h = g_hslDefaultAccent.h;
+	hslVal.s = hslVal.s * (1.0 / g_oldhslAccentS) * g_hslDefaultAccent.s;
 
-	hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s * (a / static_cast<double>(255))) + (g_hslAccentL * hslVal.s * (a / static_cast<double>(255))) - (g_defaulthslAccentL * hslVal.s);
+	hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s * (a / static_cast<double>(255))) + (g_hslAccent.l * hslVal.s * (a / static_cast<double>(255))) - (g_hslDefaultAccent.l * hslVal.s);
 
-	hslVal.h = g_hslAccentH;
-	hslVal.s = (double)hslVal.s * (double)g_hslAccentS;
+	hslVal.h = g_hslAccent.h;
+	hslVal.s = hslVal.s * g_hslAccent.s;
 
 	rgbVal = hsl2rgb(hslVal);
 
@@ -37,8 +37,8 @@ void StandardColorHandler(int& r, int& g, int& b) // dummy code
 	rgb_t rgbVal = { 255, 128, 128 };
 	hsl_t hslVal = rgb2hsl(rgbVal);
 
-	hslVal.h = g_hslAccentH;
-	hslVal.s = hslVal.s * (1 / g_oldhslAccentS) * g_hslAccentS;
+	hslVal.h = g_hslAccent.h;
+	hslVal.s = hslVal.s * (1 / g_oldhslAccentS) * g_hslAccent.s;
 
 	rgbVal = hsl2rgb(hslVal);
 }

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -780,163 +780,167 @@ void ModifyStyles()
 		}
 	}
 
-	SetCurrentTheme(L"Menu");
-	//
-	for (k = 1; k <= 7; k++)
+	if (g_bColorizeMenus)
 	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(16, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(12, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-		ModifyStyle(8, 0, k);
-		ModifyStyle(7, 0, k);
-	}
-
-	// Menu Checkbox
-	for (j = 0; j <= 7; j++)
-	{
-		for (k = 0; k <= 7; k++)
-		{
-			ModifyStyle(11, j, k);
-		}
-	}
-
-	SetCurrentTheme(L"DarkMode::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(16, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(12, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-		ModifyStyle(8, 0, k);
-		ModifyStyle(7, 0, k);
-	}
-
-	// Menu Checkbox
-	for (j = 0; j <= 7; j++)
-	{
-		for (k = 0; k <= 7; k++)
-		{
-			ModifyStyle(11, j, k);
-		}
-	}
-
-	SetCurrentTheme(L"ImmersiveStart::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"ImmersiveStartDark::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"Communications::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-	}
-
-	SetCurrentTheme(L"Media::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-	}
-
-	SetCurrentTheme(L"Progress");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(5, 4, k);
-		ModifyStyle(6, 4, k);
-	}
-	for (i = 3; i <= 12; i++)
-	{
+		SetCurrentTheme(L"Menu");
+		//
 		for (k = 1; k <= 7; k++)
 		{
-			ModifyStyle(i, 1, k);
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(16, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(12, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
+			ModifyStyle(8, 0, k);
+			ModifyStyle(7, 0, k);
 		}
-	}
+		// Menu Checkbox
+		for (j = 0; j <= 7; j++)
+		{
+			for (k = 0; k <= 7; k++)
+			{
+				ModifyStyle(11, j, k);
+			}
+		}
 
-
-	SetCurrentTheme(L"Indeterminate::Progress");
-	//
-	for (i = 3; i <= 10; i++)
-	{
+		SetCurrentTheme(L"DarkMode::Menu");
+		//
 		for (k = 1; k <= 7; k++)
 		{
-			ModifyStyle(i, 1, k);
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(16, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(12, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
+			ModifyStyle(8, 0, k);
+			ModifyStyle(7, 0, k);
+		}
+		// Menu Checkbox
+		for (j = 0; j <= 7; j++)
+		{
+			for (k = 0; k <= 7; k++)
+			{
+				ModifyStyle(11, j, k);
+			}
+		}
+
+		SetCurrentTheme(L"ImmersiveStart::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"ImmersiveStartDark::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"Communications::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
+		}
+
+		SetCurrentTheme(L"Media::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
 		}
 	}
 
-
-	SetCurrentTheme(L"AB::AddressBand");
-	//
-	for (k = 1; k <= 7; k++)
+	if (g_bColorizeProgressBar)
 	{
-		ModifyStyle(1, 4, k);
-	}
+		SetCurrentTheme(L"Progress");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(5, 4, k);
+			ModifyStyle(6, 4, k);
+		}
+		for (i = 3; i <= 12; i++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, 1, k);
+			}
+		}
 
-	SetCurrentTheme(L"DarkMode_ABComposited::AddressBand");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(i, 4, k);
+
+		SetCurrentTheme(L"Indeterminate::Progress");
+		//
+		for (i = 3; i <= 10; i++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, 1, k);
+			}
+		}
+
+
+		SetCurrentTheme(L"AB::AddressBand");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(1, 4, k);
+		}
+
+		SetCurrentTheme(L"DarkMode_ABComposited::AddressBand");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 4, k);
+		}
 	}
 
 	/** Tweaks for legacy components **/

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -12,6 +12,8 @@ double brightnessMultiplier;
 
 HTHEME hTheme = nullptr;
 
+std::set<HBITMAP> handledBitmaps;
+
 void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 {
 	rgb_t rgbVal = { r, g, b };
@@ -58,6 +60,13 @@ bool ModifyStyle(int iPartId, int iStateId, int iPropId)
 {
 	HBITMAP hBitmap;
 	GetThemeBitmap(hTheme, iPartId, iStateId, iPropId, GBF_DIRECT, &hBitmap);
+
+	if (handledBitmaps.find(hBitmap) != handledBitmaps.end())
+	{
+		return true;
+	}
+	handledBitmaps.emplace(hBitmap);
+
 	return IterateBitmap(hBitmap, StandardBitmapPixelHandler);
 }
 

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -1,5 +1,6 @@
 #include "StyleModifier.h"
 #include "BitmapHelper.h"
+#include "StyleColorHelper.h"
 #include "ColorHelper.h"
 #include "AccentColorHelper.h"
 #include "SystemHelper.h"
@@ -12,16 +13,33 @@ HTHEME hTheme = nullptr;
 void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 {
 	rgb_t rgbVal = { r, g, b };
-	hsv_t hsvVal = rgb2hsv(rgbVal);
+	hsl_t hslVal = rgb2hsl(rgbVal);
 
-	hsvVal.h = g_hsvAccentH;
+	hslVal.h = g_defaulthslAccentH;
+	hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
 
-	rgbVal = hsv2rgb(hsvVal);
+
+	hslVal.h = g_hslAccentH;
+	hslVal.s = (double)hslVal.s * (double)g_hslAccentS;
+
+	rgbVal = hsl2rgb(hslVal);
 
 	r = rgbVal.r;
 	g = rgbVal.g;
 	b = rgbVal.b;
 }
+
+void StandardColorHandler(int& r, int& g, int& b) // dummy code
+{
+	rgb_t rgbVal = { 255, 128, 128 };
+	hsl_t hslVal = rgb2hsl(rgbVal);
+
+	hslVal.h = g_hslAccentH;
+	hslVal.s = hslVal.s * (1 / g_oldhslAccentS) * g_hslAccentS;
+
+	rgbVal = hsl2rgb(hslVal);
+}
+
 
 void SetCurrentTheme(LPCWSTR pszClassList)
 {
@@ -40,6 +58,13 @@ bool ModifyStyle(int iPartId, int iStateId, int iPropId)
 	return IterateBitmap(hBitmap, StandardBitmapPixelHandler);
 }
 
+bool ModifyColorStyle(int iPartId, int iStateId, int iPropId) // dummy code
+{
+	COLORREF hColor;
+	GetThemeColor(hTheme, iPartId, iStateId, iPropId, &hColor);
+	return IterateColor(hColor, StandardColorHandler);
+}
+
 ///
 /// At first glance, such refactoring looks useless,
 /// premature and counterproductive, but
@@ -51,18 +76,20 @@ void ModifyStyles()
 	int i, j, k;
 	//
 
+	SetCurrentTheme(L"CommandModule"); // dummy code
+	//
+	ModifyColorStyle(3, 2, TMT_TEXTCOLOR);
 
 	SetCurrentTheme(VSCLASS_BUTTON);
 	//
-	ModifyStyle(BP_PUSHBUTTON, 0, TMT_DIBDATA);
+	ModifyStyle(BP_PUSHBUTTON, 0, 0);
+	ModifyStyle(BP_COMMANDLINK, 0, 0);
 	for (j = 1; j <= 7; j++)
 	{
-		ModifyStyle(BP_CHECKBOX, 0, j);
 		ModifyStyle(BP_RADIOBUTTON, 0, j);
-	}
-	for (j = 1; j <= 3; j++)
-	{
+		ModifyStyle(BP_CHECKBOX, 0, j);
 		ModifyStyle(BP_GROUPBOX, 0, j);
+		ModifyStyle(BP_COMMANDLINKGLYPH, 0, j);
 	}
 
 
@@ -70,7 +97,10 @@ void ModifyStyles()
 	//
 	for (i = CP_DROPDOWNBUTTON; i <= CP_DROPDOWNBUTTONLEFT; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+		}
 	}
 
 
@@ -78,7 +108,10 @@ void ModifyStyles()
 	//
 	for (i = EP_EDITBORDER_NOSCROLL; i <= EP_EDITBORDER_HVSCROLL; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+		}
 	}
 
 
@@ -86,7 +119,10 @@ void ModifyStyles()
 	//
 	for (i = TABP_TABITEM; i <= TABP_TOPTABITEMBOTHEDGE; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+		}
 	}
 
 
@@ -97,7 +133,6 @@ void ModifyStyles()
 		for (j = 1; j <= 7; j++)
 		{
 			ModifyStyle(i, 0, j);
-			ModifyStyle(i, 0, j);
 		}
 	}
 
@@ -106,7 +141,7 @@ void ModifyStyles()
 	//
 	for (i = LBCP_BORDER_HSCROLL; i <= LBCP_ITEM; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		ModifyStyle(i, 0, 0);
 	}
 
 
@@ -114,13 +149,16 @@ void ModifyStyles()
 	//
 	for (i = SPNP_UP; i <= SPNP_DOWNHORZ; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		ModifyStyle(i, 0, 0);
 	}
 
 
 	SetCurrentTheme(VSCLASS_HEADERSTYLE);
 	//
-	ModifyStyle(HP_HEADERITEM, 0, TMT_DIBDATA);
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(HP_HEADERITEM, 0, k);
+	}
 
 
 	/////////////////////////////////////////////////////
@@ -128,7 +166,20 @@ void ModifyStyles()
 	//
 	for (i = TP_BUTTON; i <= TP_SPLITBUTTONDROPDOWN; i++)
 	{
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
+	}
+
+	SetCurrentTheme(L"DarkMode::Toolbar");
+	//
+	for (i = TP_BUTTON; i <= TP_SPLITBUTTONDROPDOWN; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
 	}
 
 
@@ -136,7 +187,10 @@ void ModifyStyles()
 	//
 	for (i = TP_BUTTON; i <= TP_SPLITBUTTONDROPDOWN; i++)
 	{
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
 	}
 
 
@@ -144,7 +198,10 @@ void ModifyStyles()
 	//
 	for (i = TP_BUTTON; i <= TP_SPLITBUTTONDROPDOWN; i++)
 	{
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
 	}
 
 
@@ -152,7 +209,10 @@ void ModifyStyles()
 	//
 	for (i = TP_BUTTON; i <= TP_SPLITBUTTONDROPDOWN; i++)
 	{
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
 	}
 
 
@@ -160,23 +220,63 @@ void ModifyStyles()
 	//
 	for (i = TP_BUTTON; i <= TP_SPLITBUTTONDROPDOWN; i++)
 	{
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
 	}
-	/////////////////////////////////////////////////////
 
+	SetCurrentTheme(L"Placesbar::Toolbar");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 0, k);
+	}
+
+	SetCurrentTheme(L"TrayNotify::Toolbar");
+	//
+	ModifyStyle(TP_BUTTON, 1, 0);
+
+	/////////////////////////////////////////////////////
 
 	SetCurrentTheme(L"BreadcrumbBar");
 	//
-	ModifyStyle(1, 0, TMT_DIBDATA);
+	ModifyStyle(1, 0, 0);
 
+	SetCurrentTheme(L"BrowserTab");
+	//
+	for (j = 1; j <= 3; j++)
+	{
+		ModifyStyle(1, 0, j);
+	}
+
+	SetCurrentTheme(L"BrowserTabBar");
+	//
+	ModifyStyle(0, 0, 0);
 
 	SetCurrentTheme(L"Explorer::TreeView");
 	//
-	for (i = 1; i <= 6; i++)
+	for (i = 1; i <= 4; i++)
 	{
-		for (j = 1; j <= 2; j++)
+		for (j = 1; j <= 6; j++)
 		{
-			ModifyStyle(i, j, TMT_DIBDATA);
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
+		}
+	}
+
+	SetCurrentTheme(L"DarkMode_Explorer::TreeView");
+	//
+	for (i = 1; i <= 4; i++)
+	{
+		for (j = 1; j <= 6; j++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
 		}
 	}
 
@@ -187,42 +287,92 @@ void ModifyStyles()
 	{
 		for (j = 1; j <= 16; j++)
 		{
-			ModifyStyle(i, j, TMT_DIBDATA);
+			ModifyStyle(i, j, 0);
 		}
 	}
 
 
 	SetCurrentTheme(L"PreviewPane");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA); // Windows Vista/7 Explorer Bottom Details Panel
+	for (i = 1; i <= 4; i++)
+	{
+		ModifyStyle(i, 0, 0); // Windows Vista/7 Explorer Bottom Details Panel
+	}
 
+	SetCurrentTheme(L"DarkMode::PreviewPane");
+	//
+	for (i = 1; i <= 4; i++)
+	{
+		ModifyStyle(i, 0, 0); // Windows Vista/7 Explorer Bottom Details Panel
+	}
 
 	SetCurrentTheme(L"CommandModule");
 	//
 	for (i = 1; i <= 11; i++)
 	{
 		if (i == 8) continue;
-		ModifyStyle(i, 0, TMT_DIBDATA);
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		ModifyStyle(i, 0, 0);
+		ModifyStyle(i, 1, 0);
+	}
+	SetCurrentTheme(L"DarkMode::CommandModule");
+	//
+	for (i = 1; i <= 11; i++)
+	{
+		if (i == 8) continue;
+		ModifyStyle(i, 0, 0);
+		ModifyStyle(i, 1, 0);
 	}
 
 
 	SetCurrentTheme(L"ItemsView");
 	//
-	for (i = 1; i <= 7; i++)
+	for (i = 2; i <= 6; i++)
 	{
-		ModifyStyle(3, i, TMT_DIBDATA);
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+			ModifyStyle(3, 1, k);
+			ModifyStyle(3, 2, k);
+		}
+	}
+	for (j = 1; j <= 4; j++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(1, j, k);
+		}
 	}
 
-	
+	SetCurrentTheme(L"DarkMode::ItemsView");
+	//
+	for (i = 2; i <= 6; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+			ModifyStyle(3, 1, k);
+			ModifyStyle(3, 2, k);
+		}
+	}
+	for (j = 1; j <= 4; j++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(1, j, k);
+		}
+	}
+
+
 	SetCurrentTheme(L"ItemsView::Header");
 	//
-	ModifyStyle(1, 0, TMT_DIBDATA); // Explorer File Groups Header
-	for (i = 1; i <= 16; i++)
+	for (i = 1; i <= 7; i++)
 	{
-		for (j = 1; j <= 16; j++)
+		for (j = 1; j <= 12; j++)
 		{
-			ModifyStyle(i, j, TMT_DIBDATA);
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
 		}
 	}
 
@@ -234,7 +384,33 @@ void ModifyStyles()
 	{
 		for (j = 1; j <= 16; j++)
 		{
-			ModifyStyle(i, j, TMT_DIBDATA); // Explorer File Selection
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k); // Explorer File Selection
+			}
+		}
+	}
+	for (i = 8; i <= 9; i++)
+	{
+		for (j = 1; j <= 7; j++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
+		}
+	}
+
+	SetCurrentTheme(L"DarkMode_ItemsView::ListView");
+	//
+	for (i = 1; i <= 16; i++)
+	{
+		for (j = 1; j <= 16; j++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k); // Explorer File Selection
+			}
 		}
 	}
 	for (i = 8; i <= 9; i++)
@@ -251,11 +427,11 @@ void ModifyStyles()
 
 	SetCurrentTheme(L"ListView");
 	//
-	for (i = 8; i <= 9; i++)
+	for (i = 6; i <= 9; i++)
 	{
 		for (j = 1; j <= 7; j++)
 		{
-			for (k = 1; k <= 7; k++)
+			for (k = 0; k <= 7; k++)
 			{
 				ModifyStyle(i, j, k);
 			}
@@ -276,16 +452,6 @@ void ModifyStyles()
 		}
 	}
 
-
-	SetCurrentTheme(L"Explorer::TreeView");
-	//
-	for (j = 1; j <= 7; j++)
-	{
-		for (k = 1; k <= 7; k++)
-		{
-			ModifyStyle(4, j, k);
-		}
-	}
 	/////////////////////////////////////////////////////
 
 
@@ -293,35 +459,67 @@ void ModifyStyles()
 	//
 	for (i = 1; i <= 4; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA); // Explorer Breadcrumbs Highlight color
+		ModifyStyle(i, 0, 0); // Explorer Breadcrumbs Highlight color
+	}
+
+	SetCurrentTheme(L"DarkMode_BBComposited::Toolbar");
+	//
+	for (i = 1; i <= 4; i++)
+	{
+		ModifyStyle(i, 0, 0); // Explorer Breadcrumbs Highlight color
+	}
+
+	SetCurrentTheme(L"MaxInactiveBB::Toolbar");
+	//
+	for (i = 1; i <= 4; i++)
+	{
+		ModifyStyle(i, 0, 0); // Explorer Breadcrumbs Highlight color
+	}
+
+	SetCurrentTheme(L"MaxInactiveBBComposited::Toolbar");
+	//
+	for (i = 1; i <= 4; i++)
+	{
+		ModifyStyle(i, 0, 0); // Explorer Breadcrumbs Highlight color
+	}
+
+	SetCurrentTheme(L"ExplorerMenu::Toolbar");
+	//
+	for (i = 1; i <= 4; i++)
+	{
+		ModifyStyle(i, 0, 0);
 	}
 
 	/////////////////////////////////////////////////////
 	SetCurrentTheme(L"Go::Toolbar");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA);
+	ModifyStyle(1, 1, 0);
 
 
 	SetCurrentTheme(L"InactiveGo::Toolbar");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA);
+	ModifyStyle(1, 1, 0);
 	/////////////////////////////////////////////////////
 
 
 	SetCurrentTheme(L"MaxGo::Toolbar");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA);
+	ModifyStyle(1, 1, 0);
+
+	SetCurrentTheme(L"MaxInactiveGo::Toolbar");
+	//
+	ModifyStyle(1, 1, 0);
 
 
 	/////////////////////////////////////////////////////
 	SetCurrentTheme(L"LVPopup::Toolbar");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA);
+	ModifyStyle(1, 1, 0);
 
 
 	SetCurrentTheme(L"LVPopupBottom::Toolbar");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA);
+	ModifyStyle(1, 1, 0);
 	/////////////////////////////////////////////////////
 
 
@@ -329,11 +527,11 @@ void ModifyStyles()
 	/////////////////////////////////////////////////////
 	SetCurrentTheme(L"InactiveBB::Toolbar");
 	//
-	ModifyStyle(3, 1, TMT_DIBDATA);
+	ModifyStyle(3, 1, 0);
 	for (j = 1; j <= 6; j++)
 	{
 		ModifyStyle(4, j, j);
-		ModifyStyle(4, j, TMT_DIBDATA);
+		ModifyStyle(4, j, 0);
 	}
 
 
@@ -342,20 +540,30 @@ void ModifyStyles()
 	for (j = 1; j <= 6; j++)
 	{
 		ModifyStyle(4, j, j);
-		ModifyStyle(4, j, TMT_DIBDATA);
+		ModifyStyle(4, j, 0);
 	}
 	/////////////////////////////////////////////////////
 
 
 	SetCurrentTheme(L"DragDrop");
 	//
-	ModifyStyle(7, 0, TMT_DIBDATA);
-	ModifyStyle(8, 0, TMT_DIBDATA);
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 0, k);
+		ModifyStyle(2, 0, k);
+		ModifyStyle(3, 0, k);
+		ModifyStyle(4, 0, k);
+		ModifyStyle(7, 0, k);
+		ModifyStyle(8, 0, k);
+	}
 
+	SetCurrentTheme(L"DropListControl");
+	//
+	ModifyStyle(1, 0, 0);
 
 	SetCurrentTheme(L"Header");
 	//
-	ModifyStyle(1, 0, TMT_DIBDATA);
+	ModifyStyle(1, 0, 0);
 
 
 	SetCurrentTheme(L"PAUSE");
@@ -366,35 +574,30 @@ void ModifyStyles()
 	}
 
 
-	SetCurrentTheme(L"Tab");
-	//
-	for (i = 1; i <= 8; i++)
-	{
-		ModifyStyle(i, 1, TMT_DIBDATA);
-	}
-
-
 	SetCurrentTheme(VSCLASS_MONTHCAL); // Explorer / Legacy Shell Date Picker
 	//
-	for (i = 1; i <= 4; i++)
+	for (i = 10; i <= 11; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		ModifyStyle(i, 0, 0);
+		ModifyStyle(i, 1, 0);
 	}
 	for (j = 1; j <= 6; j++)
 	{
-		ModifyStyle(MC_GRIDCELLBACKGROUND, j, TMT_DIBDATA);
+		ModifyStyle(MC_GRIDCELLBACKGROUND, j, 0);
 	}
 
 
 	SetCurrentTheme(L"DatePicker");
 	//
-	for (i = 1; i <= 2; i++)
+	for (i = 2; i <= 3; i++)
 	{
 		for (j = 0; j <= 1; j++)
 		{
 			ModifyStyle(i, j, 1);
-			ModifyStyle(i, j, TMT_DIBDATA);
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
 		}
 	}
 
@@ -402,31 +605,39 @@ void ModifyStyles()
 	/////////////////////////////////////////////////////
 	SetCurrentTheme(L"Rebar");
 	//
-	ModifyStyle(6, 0, TMT_DIBDATA);
+	ModifyStyle(6, 0, 0);
 	for (i = 4; i <= 6; i++) {
-		ModifyStyle(i, 1, TMT_DIBDATA);
-		ModifyStyle(i, 1, TMT_DIBDATA);
+		ModifyStyle(i, 1, 0);
+		ModifyStyle(i, 1, 0);
 	}
+
+	SetCurrentTheme(L"Default::Rebar");
+	//
+	ModifyStyle(6, 0, 0);
+
+	SetCurrentTheme(L"ExplorerBar::Rebar");
+	//
+	ModifyStyle(6, 0, 0);
 
 
 	SetCurrentTheme(L"Navbar::Rebar");
 	//
-	ModifyStyle(6, 0, TMT_DIBDATA);
-	ModifyStyle(6, 1, TMT_DIBDATA);
+	ModifyStyle(6, 0, 0);
+	ModifyStyle(6, 1, 0);
 
 
 	SetCurrentTheme(L"InactiveNavbar::Rebar");
 	//
-	ModifyStyle(6, 0, TMT_DIBDATA);
-	ModifyStyle(6, 1, TMT_DIBDATA);
+	ModifyStyle(6, 0, 0);
+	ModifyStyle(6, 1, 0);
 	/////////////////////////////////////////////////////
 
 
 	SetCurrentTheme(L"Desktop::ListView");
 	//
-	for (j = 0; j <= 9; j++)
+	for (j = 0; j <= 6; j++)
 	{
-		ModifyStyle(1, j, TMT_DIBDATA); // Desktop icons
+		ModifyStyle(1, j, 0); // Desktop icons
 	}
 
 	/////////////////////////////////////////////////////
@@ -443,8 +654,25 @@ void ModifyStyles()
 		}
 	}
 
+	SetCurrentTheme(L"ProperTree");
+	//
+	ModifyStyle(1, 0, 0);
+
 
 	SetCurrentTheme(L"Navigation");
+	//
+	for (i = 0; i <= 10; i++)
+	{
+		for (j = 0; j <= 10; j++)
+		{
+			for (k = 0; k <= 10; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
+		}
+	}
+
+	SetCurrentTheme(L"DarkMode::Navigation");
 	//
 	for (i = 0; i <= 10; i++)
 	{
@@ -473,12 +701,29 @@ void ModifyStyles()
 
 	SetCurrentTheme(L"SearchBox");
 	//
-	for (j = 1; j <= 7; j++)
+	for (i = 1; i <= 3; i++)
 	{
-		for (k = 1; k <= 7; k++)
+		for (j = 1; j <= 7; j++)
 		{
-			ModifyStyle(2, j, k);
+			ModifyStyle(i, j, k);
 		}
+	}
+
+	SetCurrentTheme(L"DarkMode::SearchBox");
+	//
+	for (i = 1; i <= 3; i++)
+	{
+		for (j = 1; j <= 7; j++)
+		{
+			ModifyStyle(i, j, k);
+		}
+	}
+
+	SetCurrentTheme(L"HelpSearchBox");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 0, k);
 	}
 
 
@@ -510,70 +755,207 @@ void ModifyStyles()
 	//
 	for (i = (g_winver >= WIN_10 ? 6 : 8); i <= (g_winver >= WIN_10 ? 9 : 11); i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
-		ModifyStyle(i, 1, TMT_DIBDATA);
-	}
-
-	if (g_bColorizeMenus)
-	{
-		SetCurrentTheme(L"Menu");
-		//
-		ModifyStyle(14, 0, TMT_DIBDATA);
-		ModifyStyle(13, 0, TMT_DIBDATA);
-		ModifyStyle(12, 0, TMT_DIBDATA);
-		ModifyStyle(8, 0, TMT_DIBDATA);
-		ModifyStyle(7, 0, TMT_DIBDATA);
-
-		// Menu Checkbox
-		for (j = 0; j <= 7; j++)
+		for (j = 1; j <= 4; j++)
 		{
-			for (k = 0; k <= 7; k++)
+			for (k = 1; k <= 7; k++)
 			{
-				ModifyStyle(11, j, k);
+				ModifyStyle(i, j, k);
 			}
 		}
 	}
 
-	if (g_bColorizeProgressBar)
+	SetCurrentTheme(L"TaskbandExtendedUILight::TaskbandExtendedUI");	// Light Mode Taskbar Thumbnail Media Controls
+	//
+	for (i = (g_winver >= WIN_10 ? 6 : 8); i <= (g_winver >= WIN_10 ? 9 : 11); i++)
 	{
-		SetCurrentTheme(L"Progress");
-		//
-		ModifyStyle(5, 4, TMT_DIBDATA);
-		for (i = 3; i <= 10; i++)
+		for (j = 1; j <= 4; j++)
 		{
-			ModifyStyle(i, 1, TMT_DIBDATA);
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
 		}
+	}
 
+	SetCurrentTheme(L"Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(16, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(12, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+		ModifyStyle(8, 0, k);
+		ModifyStyle(7, 0, k);
+	}
 
-		SetCurrentTheme(L"Indeterminate::Progress");
-		//
-		for (i = 3; i <= 10; i++)
+	// Menu Checkbox
+	for (j = 0; j <= 7; j++)
+	{
+		for (k = 0; k <= 7; k++)
 		{
-			ModifyStyle(i, 1, TMT_DIBDATA);
+			ModifyStyle(11, j, k);
 		}
+	}
+
+	SetCurrentTheme(L"DarkMode::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(16, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(12, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+		ModifyStyle(8, 0, k);
+		ModifyStyle(7, 0, k);
+	}
+
+	// Menu Checkbox
+	for (j = 0; j <= 7; j++)
+	{
+		for (k = 0; k <= 7; k++)
+		{
+			ModifyStyle(11, j, k);
+		}
+	}
+
+	SetCurrentTheme(L"ImmersiveStart::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"ImmersiveStartDark::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+	}
+
+	SetCurrentTheme(L"Communications::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+	}
+
+	SetCurrentTheme(L"Media::Menu");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(27, 0, k);
+		ModifyStyle(26, 0, k);
+		ModifyStyle(15, 0, k);
+		ModifyStyle(14, 0, k);
+		ModifyStyle(13, 0, k);
+		ModifyStyle(10, 0, k);
+		ModifyStyle(9, 0, k);
+	}
+
+	SetCurrentTheme(L"Progress");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(5, 4, k);
+		ModifyStyle(6, 4, k);
+	}
+	for (i = 3; i <= 12; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
+	}
 
 
-		SetCurrentTheme(L"AB::AddressBand");
-		//
-		ModifyStyle(1, 1, TMT_DIBDATA);
+	SetCurrentTheme(L"Indeterminate::Progress");
+	//
+	for (i = 3; i <= 10; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 1, k);
+		}
+	}
+
+
+	SetCurrentTheme(L"AB::AddressBand");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 4, k);
+	}
+
+	SetCurrentTheme(L"DarkMode_ABComposited::AddressBand");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(i, 4, k);
 	}
 
 	/** Tweaks for legacy components **/
 
 	SetCurrentTheme(L"Communications::Rebar");
 	//
-	ModifyStyle(6, 0, TMT_DIBDATA);
+	ModifyStyle(6, 0, 0);
+
+	SetCurrentTheme(L"Media::Rebar");
+	//
+	ModifyStyle(6, 0, 0);
 
 
 	SetCurrentTheme(L"StartPanel");
 	//
-	ModifyStyle(1, 1, TMT_DIBDATA);
+	ModifyStyle(1, 1, 0);
 
 
 	SetCurrentTheme(L"StartMenu::Toolbar");
 	//
-	ModifyStyle(10, 1, TMT_DIBDATA);
-	ModifyStyle(12, 1, TMT_DIBDATA);
+	ModifyStyle(10, 1, 0);
+	ModifyStyle(12, 1, 0);
 
 
 	/////////////////////////////////////////////////////
@@ -581,7 +963,7 @@ void ModifyStyles()
 	//
 	for (i = 1; i <= 38; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		ModifyStyle(i, 0, 0);
 	}
 
 
@@ -589,101 +971,153 @@ void ModifyStyles()
 	//
 	for (i = 1; i <= 38; i++)
 	{
-		ModifyStyle(i, 0, TMT_DIBDATA);
+		ModifyStyle(i, 0, 0);
 	}
 	/////////////////////////////////////////////////////
 
-	if (g_winver < WIN_8)
+	SetCurrentTheme(L"TaskDialog");
+	//
+	for (i = 1; i <= 8; i++)
 	{
-		SetCurrentTheme(L"TaskDialog");
-		//
-		for (i = 1; i <= 8; i++)
+		for (k = 1; k <= 7; k++)
 		{
-			ModifyStyle(13, i, TMT_DIBDATA);
+			ModifyStyle(13, i, k);
 		}
+	}
 
 
-		/////////////////////////////////////////////////////
-		SetCurrentTheme(L"Header");
-		//
-		for (i = 1; i <= 7; i++)
+	/////////////////////////////////////////////////////
+	SetCurrentTheme(L"Header");
+	//
+	for (i = 1; i <= 7; i++)
+	{
+		for (j = 1; j <= 12; j++)
 		{
-			for (j = 1; j <= 12; j++)
+			for (k = 1; k <= 7; k++)
 			{
-				for (k = 1; k <= 7; k++)
-				{
-					ModifyStyle(i, j, k);
-				}
+				ModifyStyle(i, j, k);
 			}
 		}
+	}
+
+	/////////////////////////////////////////////////////
 
 
-		SetCurrentTheme(L"ItemsView::Header");
-		//
-		for (i = 1; i <= 7; i++)
-		{
-			for (j = 1; j <= 12; j++)
-			{
-				for (k = 1; k <= 7; k++)
-				{
-					ModifyStyle(i, j, k);
-				}
-			}
-		}
-		/////////////////////////////////////////////////////
-
-
-		SetCurrentTheme(L"ScrollBar");
-		//
-		for (i = 1; i <= 10; i++)
-		{
-			for (k = 1; k <= 4; k++)
-			{
-				ModifyStyle(i, 0, k);
-			}
-		}
-
-		//
-		// Aero Basic
-		//
-
-
-		SetCurrentTheme(L"TaskBar2::TaskBar");
-		//
-		for (i = 1; i <= 8; i++)
-		{
-			ModifyStyle(i, 0, 0);
-		}
-
-
-		SetCurrentTheme(L"AltTab");
-		//
-		for (i = 1; i <= 11; i++)
-		{
-			ModifyStyle(i, 0, TMT_DIBDATA);
-		}
-
-
-		SetCurrentTheme(L"BasicMenuMode::TaskbandExtendedUI");
-		//
-		ModifyStyle(1, 0, 0);
-
-
-		SetCurrentTheme(L"Window");
-		//
-		for (i = 1; i <= 13; i++)
-		{
-			ModifyStyle(i, 0, 0);
-		}
-		ModifyStyle(15, 4, 0);
-		ModifyStyle(17, 4, 0);
-		ModifyStyle(18, 4, 0);
-		ModifyStyle(19, 4, 0);
-		ModifyStyle(21, 4, 0);
-		ModifyStyle(23, 4, 0);
+	SetCurrentTheme(L"ScrollBar");
+	//
+	for (i = 1; i <= 10; i++)
+	{
+		ModifyStyle(i, 0, 0);
 	}
 
 	//
+	// Aero Basic
+	//
+
+
+	SetCurrentTheme(L"TaskBar2::TaskBar");
+	//
+	for (i = 1; i <= 8; i++)
+	{
+		ModifyStyle(i, 0, 0);
+	}
+
+
+	SetCurrentTheme(L"AltTab");
+	//
+	for (i = 1; i <= 11; i++)
+	{
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(i, 0, k);
+		}
+	}
+
+	SetCurrentTheme(L"Tooltip");
+	//
+	for (i = 1; i <= 6; i++)
+	{
+		ModifyStyle(i, 0, 0);
+	}
+
+
+	SetCurrentTheme(L"BasicMenuMode::TaskbandExtendedUI");
+	//
+	ModifyStyle(1, 0, 0);
+
+	SetCurrentTheme(L"Flyout");
+	//
+	ModifyStyle(5, 0, 0);
+	ModifyStyle(6, 0, 0);
+
+	SetCurrentTheme(L"Window");
+	//
+	for (i = 1; i <= 17; i++)
+	{
+		ModifyStyle(i, 0, 0);
+	}
+	for (i = 21; i <= 23; i++)
+	{
+		ModifyStyle(i, 0, 0);
+	}
+
+	//
+	// Metro UI custom controls
+	SetCurrentTheme(L"DirectUI::Button");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 0, k);
+		ModifyStyle(2, 0, k);
+		ModifyStyle(3, 0, k);
+		ModifyStyle(6, 0, k);
+	}
+
+	SetCurrentTheme(L"DirectUIDark::Button");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(2, 0, k);
+		ModifyStyle(3, 0, k);
+		ModifyStyle(6, 0, k);
+	}
+
+	SetCurrentTheme(L"DirectUILight::Button");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(2, 0, k);
+		ModifyStyle(3, 0, k);
+		ModifyStyle(6, 0, k);
+	}
+
+	SetCurrentTheme(L"PillTab::Tab");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 0, k);
+	}
+
+	SetCurrentTheme(L"PillTabHighDPI::Tab");
+	//
+	for (k = 1; k <= 7; k++)
+	{
+		ModifyStyle(1, 0, k);
+	}
+
+	SetCurrentTheme(L"TouchSlider::TrackBar");
+	//
+	for (i = 1; i <= 6; i++)
+	{
+		for (j = 1; j <= 5; j++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, j, k);
+			}
+		}
+	}
+
 	CloseThemeData(hTheme);
 	hTheme = nullptr;
 }

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -22,7 +22,7 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 	rgbVal.b = rgbVal.b / (a / 255.0);
 	hsl_t hslVal = rgb2hsl(rgbVal);
 
-	g_hslEnhancedAccentHL = (g_hslDefaultAccent.l * 255) - g_hslAccent.l;
+	g_hslEnhancedAccentHL = (g_hslDefaultAccent.l * 255.0) - g_hslAccent.l;
 
 	hslVal.h = g_hslDefaultAccent.h;
 	if (hslVal.l >= 128 && hslVal.l <= 254) {
@@ -31,15 +31,18 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 	else hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s;
 
 	if (hslVal.l > (g_oldhslEnhancedAccentL)) {
-		hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL + (0.008 * ((hslVal.l - g_oldhslEnhancedAccentL) * g_oldhslAccentL))) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
+		if (g_oldhslAccentL < g_hslAccent.l && g_oldhslEnhancedAccentL > 107) {
+			hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL + (0.000042 * (200 + g_oldhslAccentL) * ((hslVal.l - g_oldhslEnhancedAccentL) * g_oldhslAccentL))) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
+		}
+		else hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
 	}
-	else hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL) * hslVal.s);
+	else hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l) * hslVal.s;
 
 	if (hslVal.l > g_hslEnhancedAccentHL) {
-		hslVal.h = g_hslAccent.h + 0.55 * ((g_hslLightAccentH - g_hslAccent.h) * ((hslVal.l - g_hslEnhancedAccentHL) / (255.0 - g_hslEnhancedAccentHL)));
+		hslVal.h = g_hslAccent.h + 0.5 * ((g_hslLightAccentH - g_hslAccent.h) * ((hslVal.l - g_hslEnhancedAccentHL) / (255.0 - g_hslEnhancedAccentHL)));
 	}
 	else if (hslVal.l <= g_hslEnhancedAccentHL) {
-		hslVal.h = g_hslAccent.h + 0.55 * ((g_hslDarkAccentH - g_hslAccent.h) * ((g_hslEnhancedAccentHL - hslVal.l) / g_hslEnhancedAccentHL));
+		hslVal.h = g_hslAccent.h + 0.5 * ((g_hslDarkAccentH - g_hslAccent.h) * ((g_hslEnhancedAccentHL - hslVal.l) / g_hslEnhancedAccentHL));
 	}
 
 	if (hslVal.l >= 128 && hslVal.l <= 254) {
@@ -810,150 +813,153 @@ void ModifyStyles()
 		}
 	}
 
-	SetCurrentTheme(L"Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(16, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(12, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-		ModifyStyle(8, 0, k);
-		ModifyStyle(7, 0, k);
-	}
-
-	// Menu Checkbox
-	for (j = 0; j <= 7; j++)
-	{
-		for (k = 0; k <= 7; k++)
-		{
-			ModifyStyle(11, j, k);
-		}
-	}
-
-	SetCurrentTheme(L"DarkMode::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(16, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(12, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-		ModifyStyle(8, 0, k);
-		ModifyStyle(7, 0, k);
-	}
-
-	// Menu Checkbox
-	for (j = 0; j <= 7; j++)
-	{
-		for (k = 0; k <= 7; k++)
-		{
-			ModifyStyle(11, j, k);
-		}
-	}
-
-	SetCurrentTheme(L"ImmersiveStart::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"ImmersiveStartDark::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-	}
-
-	SetCurrentTheme(L"Communications::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-	}
-
-	SetCurrentTheme(L"Media::Menu");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(27, 0, k);
-		ModifyStyle(26, 0, k);
-		ModifyStyle(15, 0, k);
-		ModifyStyle(14, 0, k);
-		ModifyStyle(13, 0, k);
-		ModifyStyle(10, 0, k);
-		ModifyStyle(9, 0, k);
-	}
-
-	SetCurrentTheme(L"Progress");
-	//
-	for (k = 1; k <= 7; k++)
-	{
-		ModifyStyle(5, 4, k);
-		ModifyStyle(6, 4, k);
-	}
-	for (i = 3; i <= 12; i++)
-	{
+	if (g_bColorizeMenus) {
+		SetCurrentTheme(L"Menu");
+		//
 		for (k = 1; k <= 7; k++)
 		{
-			ModifyStyle(i, 1, k);
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(16, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(12, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
+			ModifyStyle(8, 0, k);
+			ModifyStyle(7, 0, k);
 		}
-	}
 
+		// Menu Checkbox
+		for (j = 0; j <= 7; j++)
+		{
+			for (k = 0; k <= 7; k++)
+			{
+				ModifyStyle(11, j, k);
+			}
+		}
 
-	SetCurrentTheme(L"Indeterminate::Progress");
-	//
-	for (i = 3; i <= 10; i++)
-	{
+		SetCurrentTheme(L"DarkMode::Menu");
+		//
 		for (k = 1; k <= 7; k++)
 		{
-			ModifyStyle(i, 1, k);
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(16, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(12, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
+			ModifyStyle(8, 0, k);
+			ModifyStyle(7, 0, k);
+		}
+
+		// Menu Checkbox
+		for (j = 0; j <= 7; j++)
+		{
+			for (k = 0; k <= 7; k++)
+			{
+				ModifyStyle(11, j, k);
+			}
+		}
+
+		SetCurrentTheme(L"ImmersiveStart::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"ImmersiveStartDark::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"DarkMode_ImmersiveStart::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"LightMode_ImmersiveStart::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+		}
+
+		SetCurrentTheme(L"Communications::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
+		}
+
+		SetCurrentTheme(L"Media::Menu");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(27, 0, k);
+			ModifyStyle(26, 0, k);
+			ModifyStyle(15, 0, k);
+			ModifyStyle(14, 0, k);
+			ModifyStyle(13, 0, k);
+			ModifyStyle(10, 0, k);
+			ModifyStyle(9, 0, k);
 		}
 	}
 
+	if (g_bColorizeProgressBar) {
+		SetCurrentTheme(L"Progress");
+		//
+		for (k = 1; k <= 7; k++)
+		{
+			ModifyStyle(5, 4, k);
+			ModifyStyle(6, 4, k);
+		}
+		for (i = 3; i <= 12; i++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, 1, k);
+			}
+		}
+
+
+		SetCurrentTheme(L"Indeterminate::Progress");
+		//
+		for (i = 3; i <= 10; i++)
+		{
+			for (k = 1; k <= 7; k++)
+			{
+				ModifyStyle(i, 1, k);
+			}
+		}
+	}
 
 	SetCurrentTheme(L"AB::AddressBand");
 	//

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -78,12 +78,7 @@ void ModifyStyles()
 {
 	int i, j, k;
 	//
-
-	SetCurrentTheme(L"DirectUI::Button"); // Explorer / Legacy Shell Date Picker
-	//
-	ModifyStyle(1, 0, 0);
-
-
+	
 	SetCurrentTheme(L"CommandModule"); // dummy code
 	//
 	ModifyColorStyle(3, 2, TMT_TEXTCOLOR);

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -4,9 +4,11 @@
 #include "ColorHelper.h"
 #include "AccentColorHelper.h"
 #include "SystemHelper.h"
+#include <cmath>
 
 bool g_bColorizeMenus;
 bool g_bColorizeProgressBar;
+double brightnessMultiplier;
 
 HTHEME hTheme = nullptr;
 
@@ -18,6 +20,7 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 	hslVal.h = g_defaulthslAccentH;
 	hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
 
+	hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s * (a / static_cast<double>(255))) + (g_hslAccentL * hslVal.s * (a / static_cast<double>(255))) - (g_defaulthslAccentL * hslVal.s);
 
 	hslVal.h = g_hslAccentH;
 	hslVal.s = (double)hslVal.s * (double)g_hslAccentS;

--- a/AccentColorizer/StyleModifier.cpp
+++ b/AccentColorizer/StyleModifier.cpp
@@ -20,7 +20,7 @@ void StandardBitmapPixelHandler(int& r, int& g, int& b, int& a)
 	hslVal.h = g_hslDefaultAccent.h;
 	hslVal.s = hslVal.s * (1.0 / g_oldhslAccentS) * g_hslDefaultAccent.s;
 
-	hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s * (a / static_cast<double>(255))) + (g_hslAccent.l * hslVal.s * (a / static_cast<double>(255))) - (g_hslDefaultAccent.l * hslVal.s);
+	hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s * (a / 255.0)) + (g_hslAccent.l * hslVal.s * (a / 255.0)) - (g_hslDefaultAccent.l * hslVal.s);
 
 	hslVal.h = g_hslAccent.h;
 	hslVal.s = hslVal.s * g_hslAccent.s;

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -38,7 +38,7 @@ void ModifySysColors()
 		hslVal = rgb2hsl(rgbVal);
 
 		if (accentColorChanges == 1) {
-			hslVal.l = hslVal.l + (18.0 * hslVal.s);
+			hslVal.l = hslVal.l + (5.1 * hslVal.s);
 		}
 
 		hslVal.h = g_hslDefaultAccent.h;
@@ -47,7 +47,7 @@ void ModifySysColors()
 		}
 		else hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s;
 
-		hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l - (3.6 * (g_hslDefaultAccent.l - (g_hslAccent.l / 255)))) * (1 - (hslVal.l / 255.0)) * hslVal.s;
+		hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l /* - (3.6 * (g_hslDefaultAccent.l - (g_hslAccent.l / 255)))) * (1 - (hslVal.l / 255.0) */) * hslVal.s;
 
 		hslVal.h = g_hslAccent.h;
 

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -37,13 +37,13 @@ void ModifySysColors()
 		};
 		hslVal = rgb2hsl(rgbVal);
 
-		hslVal.h = g_defaulthslAccentH;
-		hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
+		hslVal.h = g_hslDefaultAccent.h;
+		hslVal.s = hslVal.s * (1 / g_oldhslAccentS) * g_hslDefaultAccent.s;
 
-		hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s) + (g_hslAccentL * hslVal.s) -  (g_defaulthslAccentL * hslVal.s);
+		hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s) + (g_hslAccent.l * hslVal.s) -  (g_hslDefaultAccent.l * hslVal.s);
 
-		hslVal.h = g_hslAccentH;
-		hslVal.s = (double)hslVal.s * (double)g_hslAccentS;
+		hslVal.h = g_hslAccent.h;
+		hslVal.s = hslVal.s * g_hslAccent.s;
 
 
 

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -23,12 +23,16 @@ void ModifySysColors()
 	DWORD aNewColors[nSysElements];
 
 	COLORREF dwCurrentColor;
-	rgb_t rgbVal;
-	hsl_t hslVal;
+	rgb_t rgbVal{};
+	hsl_t hslVal{};
 
 	for (int i = 0; i < nSysElements; i++)
 	{
 		dwCurrentColor = GetSysColor(aSysElements[i]);
+
+		if (accentColorChanges == 1) {
+			hslVal.l = hslVal.l - (5.1 * hslVal.s);
+		}
 
 		rgbVal = {
 			(double)GetRValue(dwCurrentColor),
@@ -36,10 +40,6 @@ void ModifySysColors()
 			(double)GetBValue(dwCurrentColor)
 		};
 		hslVal = rgb2hsl(rgbVal);
-
-		if (accentColorChanges == 1) {
-			hslVal.l = hslVal.l + (5.1 * hslVal.s);
-		}
 
 		hslVal.h = g_hslDefaultAccent.h;
 		if (hslVal.l >= 128 && hslVal.l <= 254) {

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -37,15 +37,24 @@ void ModifySysColors()
 		};
 		hslVal = rgb2hsl(rgbVal);
 
-		hslVal.h = g_hslDefaultAccent.h;
-		hslVal.s = hslVal.s * (1 / g_oldhslAccentS) * g_hslDefaultAccent.s;
+		if (accentColorChanges == 1) {
+			hslVal.l = hslVal.l + (18.0 * hslVal.s);
+		}
 
-		hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s) + (g_hslAccent.l * hslVal.s) -  (g_hslDefaultAccent.l * hslVal.s);
+		hslVal.h = g_hslDefaultAccent.h;
+		if (hslVal.l >= 128 && hslVal.l <= 254) {
+			hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s / ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
+		}
+		else hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s;
+
+		hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l - (3.6 * (g_hslDefaultAccent.l - (g_hslAccent.l / 255)))) * (1 - (hslVal.l / 255.0)) * hslVal.s;
 
 		hslVal.h = g_hslAccent.h;
-		hslVal.s = hslVal.s * g_hslAccent.s;
 
-
+		if (hslVal.l >= 128 && hslVal.l <= 254) {
+			hslVal.s = (double)hslVal.s * (double)g_hslAccent.s * ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
+		}
+		else hslVal.s = (double)hslVal.s * (double)g_hslAccent.s;
 
 		rgbVal = hsl2rgb(hslVal);
 

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -5,6 +5,8 @@
 constexpr int aSysElements[] = {
 	COLOR_ACTIVECAPTION,
 	COLOR_GRADIENTACTIVECAPTION,
+	COLOR_INACTIVECAPTION,
+	COLOR_GRADIENTINACTIVECAPTION,
 	COLOR_HIGHLIGHT,
 	COLOR_HOTLIGHT,
 	COLOR_MENUHILIGHT
@@ -17,7 +19,7 @@ void ModifySysColors()
 
 	COLORREF dwCurrentColor;
 	rgb_t rgbVal;
-	hsv_t hsvVal;
+	hsl_t hslVal;
 
 	for (int i = 0; i < nSysElements; i++)
 	{
@@ -28,11 +30,16 @@ void ModifySysColors()
 			(double)GetGValue(dwCurrentColor),
 			(double)GetBValue(dwCurrentColor)
 		};
-		hsvVal = rgb2hsv(rgbVal);
+		hslVal = rgb2hsl(rgbVal);
 
-		hsvVal.h = g_hsvAccentH;
+		hslVal.h = g_defaulthslAccentH;
+		hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
 
-		rgbVal = hsv2rgb(hsvVal);
+
+		hslVal.h = g_hslAccentH;
+		hslVal.s = (double)hslVal.s * (double)g_hslAccentS;
+
+		rgbVal = hsl2rgb(hslVal);
 
 		aNewColors[i] = RGB(rgbVal.r, rgbVal.g, rgbVal.b);
 	}

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -1,6 +1,9 @@
 #include "SysColorsModifier.h"
 #include "ColorHelper.h"
 #include "AccentColorHelper.h"
+#include <cmath>
+
+double g_hslEnhancedAccentHL2{};
 
 constexpr int aSysElements[] = {
 	COLOR_ACTIVECAPTION,
@@ -37,15 +40,30 @@ void ModifySysColors()
 		};
 		hslVal = rgb2hsl(rgbVal);
 
+		// While this is a straight up copy of the bitmap colorization, at least it works properly... old code is below.
+
+		g_hslEnhancedAccentHL2 = (g_hslDefaultAccent.l * 255.0) - g_hslAccent.l;
+
 		hslVal.h = g_hslDefaultAccent.h;
 		if (hslVal.l >= 128 && hslVal.l <= 254) {
 			hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s / ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
 		}
 		else hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s;
 
-		hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l /* - (3.6 * (g_hslDefaultAccent.l - (g_hslAccent.l / 255)))) * (1 - (hslVal.l / 255.0) */) * hslVal.s;
+		if (hslVal.l > (g_oldhslEnhancedAccentL)) {
+			if (g_oldhslAccentL < g_hslAccent.l && g_oldhslEnhancedAccentL > 107) {
+				hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL + (0.000042 * (200 + g_oldhslAccentL) * ((hslVal.l - g_oldhslEnhancedAccentL) * g_oldhslAccentL))) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
+			}
+			else hslVal.l = hslVal.l + ((g_hslAccent.l - g_oldhslAccentL) * (pow(1 - ((hslVal.l - g_oldhslEnhancedAccentL) / 255.0), 2.0)) * hslVal.s);
+		}
+		else hslVal.l = hslVal.l - ((g_oldhslAccentL - g_hslAccent.l) * hslVal.s);
 
-		hslVal.h = g_hslAccent.h;
+		if (hslVal.l > g_hslEnhancedAccentHL2) {
+			hslVal.h = g_hslAccent.h + 0.5 * ((g_hslLightAccentH - g_hslAccent.h) * ((hslVal.l - g_hslEnhancedAccentHL2) / (255.0 - g_hslEnhancedAccentHL2)));
+		}
+		else if (hslVal.l <= g_hslEnhancedAccentHL2) {
+			hslVal.h = g_hslAccent.h + 0.5 * ((g_hslDarkAccentH - g_hslAccent.h) * ((g_hslEnhancedAccentHL2 - hslVal.l) / g_hslEnhancedAccentHL2));
+		}
 
 		if (hslVal.l >= 128 && hslVal.l <= 254) {
 			hslVal.s = (double)hslVal.s * (double)g_hslAccent.s * ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
@@ -55,11 +73,34 @@ void ModifySysColors()
 		rgbVal = hsl2rgb(hslVal);
 
 		aNewColors[i] = RGB(rgbVal.r, rgbVal.g, rgbVal.b);
+		
 	}
 
 	SetSysColors(nSysElements, aSysElements, aNewColors);
 
-/*	rgbVal = {							// code for changing highlighttext to black when highlight is too bright. doesn't work good enough.
+	// old code
+
+	/*hslVal.h = g_hslDefaultAccent.h;
+	if (hslVal.l >= 128 && hslVal.l <= 254) {
+		hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s / ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
+	}
+	else hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_hslDefaultAccent.s;
+
+	hslVal.l = hslVal.l - (g_oldhslAccentL - g_hslAccent.l  - (3.6 * (g_hslDefaultAccent.l - (g_hslAccent.l / 255)))) * (1 - (hslVal.l / 255.0) ) * hslVal.s;
+
+	hslVal.h = g_hslAccent.h;
+
+	if (hslVal.l >= 128 && hslVal.l <= 254) {
+		hslVal.s = (double)hslVal.s * (double)g_hslAccent.s * ((1.0 - (hslVal.l / 255.0)) / (hslVal.l / 255.0));
+	}
+	else hslVal.s = (double)hslVal.s * (double)g_hslAccent.s;
+
+	rgbVal = hsl2rgb(hslVal);*/
+
+
+	// code for changing highlighttext to black when highlight is too bright. doesn't work good enough.
+
+	/*rgbVal = {
 	(double)GetRValue(COLOR_HIGHLIGHT),
 	(double)GetGValue(COLOR_HIGHLIGHT),
 	(double)GetBValue(COLOR_HIGHLIGHT)

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -13,6 +13,11 @@ constexpr int aSysElements[] = {
 };
 constexpr size_t nSysElements = sizeof(aSysElements) / sizeof(*aSysElements);
 
+constexpr int aSysElements2[] = {
+	COLOR_HIGHLIGHTTEXT,
+};
+constexpr size_t nSysElements2 = sizeof(aSysElements2) / sizeof(*aSysElements2);
+
 void ModifySysColors()
 {
 	DWORD aNewColors[nSysElements];
@@ -35,9 +40,12 @@ void ModifySysColors()
 		hslVal.h = g_defaulthslAccentH;
 		hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
 
+		hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s) + (g_hslAccentL * hslVal.s) -  (g_defaulthslAccentL * hslVal.s);
 
 		hslVal.h = g_hslAccentH;
 		hslVal.s = (double)hslVal.s * (double)g_hslAccentS;
+
+
 
 		rgbVal = hsl2rgb(hslVal);
 
@@ -45,4 +53,43 @@ void ModifySysColors()
 	}
 
 	SetSysColors(nSysElements, aSysElements, aNewColors);
+
+/*	rgbVal = {							// code for changing highlighttext to black when highlight is too bright. doesn't work good enough.
+	(double)GetRValue(COLOR_HIGHLIGHT),
+	(double)GetGValue(COLOR_HIGHLIGHT),
+	(double)GetBValue(COLOR_HIGHLIGHT)
+	};
+	hslVal = rgb2hsl(rgbVal);
+
+	hslVal.h = g_defaulthslAccentH;
+	hslVal.s = (double)hslVal.s * (double)(1 / (double)g_oldhslAccentS) * (double)g_defaulthslAccentS;
+
+	hslVal.l = hslVal.l - (g_oldhslAccentL * hslVal.s) + (g_hslAccentL * hslVal.s);
+
+	hslVal.h = g_hslAccentH;
+	hslVal.s = (double)hslVal.s * (double)g_hslAccentS;
+
+	DWORD aNewColors2[nSysElements2];
+	int i = 0;
+		if (hslVal.h >= 120 && hslVal.h <= 180) {
+			if (hslVal.l >= 120) {
+				aNewColors2[i] = RGB(0, 0, 0);
+			}
+		}
+		else if (hslVal.h >= 60 && hslVal.h < 120 || hslVal.h > 180 && hslVal.h <= 240) {
+			if (hslVal.l >= 145) {
+				aNewColors2[i] = RGB(0, 0, 0);
+			}
+		}
+		else if (hslVal.h >= 0 && hslVal.h < 60 || hslVal.h > 240 && hslVal.h <= 360) {
+			if (hslVal.l >= 170) {
+				aNewColors2[i] = RGB(0, 0, 0);
+			}
+		}
+		else if (hslVal.h >= 0 && hslVal.h <= 360) {
+			if (hslVal.l >= 0) {
+				aNewColors2[i] = RGB(255, 255, 255);
+			}
+		}
+	SetSysColors(nSysElements2, aSysElements2, aNewColors2); */
 }

--- a/AccentColorizer/SysColorsModifier.cpp
+++ b/AccentColorizer/SysColorsModifier.cpp
@@ -30,10 +30,6 @@ void ModifySysColors()
 	{
 		dwCurrentColor = GetSysColor(aSysElements[i]);
 
-		if (accentColorChanges == 1) {
-			hslVal.l = hslVal.l - (5.1 * hslVal.s);
-		}
-
 		rgbVal = {
 			(double)GetRValue(dwCurrentColor),
 			(double)GetGValue(dwCurrentColor),

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,4,0
- PRODUCTVERSION 1,3,4,0
+ FILEVERSION 1,3,5,0
+ PRODUCTVERSION 1,3,5,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -77,14 +77,14 @@ BEGIN
     BEGIN
         BLOCK "040004b0"
         BEGIN
-            VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
+            VALUE "CompanyName", "krlvm, Rectify11 Team"
             VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.3.4.0"
+            VALUE "FileVersion", "1.3.5.0"
             VALUE "InternalName", "AccentColorizer.exe"
-            VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
+            VALUE "LegalCopyright", "Copyright krlvm, Rectify11 Team (C) 2021-2024"
             VALUE "OriginalFilename", "AccentColorizer.exe"
             VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.3.4.0"
+            VALUE "ProductVersion", "1.3.5.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,3,0
- PRODUCTVERSION 1,3,3,0
+ FILEVERSION 1,3,3,1
+ PRODUCTVERSION 1,3,3,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
             VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.3.3.0"
+            VALUE "FileVersion", "1.3.3.1"
             VALUE "InternalName", "AccentColorizer.exe"
             VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
             VALUE "OriginalFilename", "AccentColorizer.exe"
             VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.3.3.0"
+            VALUE "ProductVersion", "1.3.3.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,2,0
- PRODUCTVERSION 1,3,2,0
+ FILEVERSION 1,3,3,0
+ PRODUCTVERSION 1,3,3,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
             VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.3.2.0"
+            VALUE "FileVersion", "1.3.3.0"
             VALUE "InternalName", "AccentColorizer.exe"
             VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
             VALUE "OriginalFilename", "AccentColorizer.exe"
             VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.3.2.0"
+            VALUE "ProductVersion", "1.3.3.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,0,0
- PRODUCTVERSION 1,3,0,0
+ FILEVERSION 1,3,1,0
+ PRODUCTVERSION 1,3,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
             VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.3.0.0"
+            VALUE "FileVersion", "1.3.1.0"
             VALUE "InternalName", "AccentColorizer.exe"
             VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
             VALUE "OriginalFilename", "AccentColorizer.exe"
             VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.3.0.0"
+            VALUE "ProductVersion", "1.3.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -13,55 +13,6 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// Neutral (Default) resources
-
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEUD)
-LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
-#pragma code_page(1251)
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Version
-//
-
-VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,2,0,0
- PRODUCTVERSION 1,2,0,0
- FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x1L
-#else
- FILEFLAGS 0x0L
-#endif
- FILEOS 0x40004L
- FILETYPE 0x1L
- FILESUBTYPE 0x0L
-BEGIN
-    BLOCK "StringFileInfo"
-    BEGIN
-        BLOCK "040004b0"
-        BEGIN
-            VALUE "CompanyName", "krlvm"
-            VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.2.0.0"
-            VALUE "InternalName", "AccentColorizer.exe"
-            VALUE "LegalCopyright", "Copyright krlvm (C) 2021-2023"
-            VALUE "OriginalFilename", "AccentColorizer.exe"
-            VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.2.0.0"
-        END
-    END
-    BLOCK "VarFileInfo"
-    BEGIN
-        VALUE "Translation", 0x400, 1200
-    END
-END
-
-#endif    // Neutral (Default) resources
-/////////////////////////////////////////////////////////////////////////////
-
-
-/////////////////////////////////////////////////////////////////////////////
 // Russian (Russia) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_RUS)
@@ -94,6 +45,55 @@ END
 #endif    // APSTUDIO_INVOKED
 
 #endif    // Russian (Russia) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral (Default) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEUD)
+LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
+#pragma code_page(1252)
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,3,0,0
+ PRODUCTVERSION 1,3,0,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040004b0"
+        BEGIN
+            VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
+            VALUE "FileDescription", "AccentColorizer"
+            VALUE "FileVersion", "1.3.0.0"
+            VALUE "InternalName", "AccentColorizer.exe"
+            VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
+            VALUE "OriginalFilename", "AccentColorizer.exe"
+            VALUE "ProductName", "AccentColorizer"
+            VALUE "ProductVersion", "1.3.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x400, 1200
+    END
+END
+
+#endif    // Neutral (Default) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,3,1
- PRODUCTVERSION 1,3,3,1
+ FILEVERSION 1,3,4,0
+ PRODUCTVERSION 1,3,4,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
             VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.3.3.1"
+            VALUE "FileVersion", "1.3.4.0"
             VALUE "InternalName", "AccentColorizer.exe"
             VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
             VALUE "OriginalFilename", "AccentColorizer.exe"
             VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.3.3.1"
+            VALUE "ProductVersion", "1.3.4.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/AccentColorizer/VersionInfo.rc
+++ b/AccentColorizer/VersionInfo.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,1,0
- PRODUCTVERSION 1,3,1,0
+ FILEVERSION 1,3,2,0
+ PRODUCTVERSION 1,3,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "krlvm, Rounak, WinExperiments"
             VALUE "FileDescription", "AccentColorizer"
-            VALUE "FileVersion", "1.3.1.0"
+            VALUE "FileVersion", "1.3.2.0"
             VALUE "InternalName", "AccentColorizer.exe"
             VALUE "LegalCopyright", "Copyright krlvm, Rounak, WinExperiments (C) 2021-2024"
             VALUE "OriginalFilename", "AccentColorizer.exe"
             VALUE "ProductName", "AccentColorizer"
-            VALUE "ProductVersion", "1.3.1.0"
+            VALUE "ProductVersion", "1.3.2.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/AccentColorizer/main.cpp
+++ b/AccentColorizer/main.cpp
@@ -46,8 +46,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			accentColorChanges = 1;
 		}
 		else if (message == WM_DWMCOLORIZATIONCOLORCHANGED || (message == WM_WTSSESSION_CHANGE && wParam == WTS_SESSION_UNLOCK)) {
-			accentColorChanges++;
-			accentColorChanges++;
+			accentColorChanges = 2 + accentColorChanges;
 		}
 		else {
 			accentColorChanges = 0;

--- a/AccentColorizer/main.cpp
+++ b/AccentColorizer/main.cpp
@@ -42,7 +42,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			//  d) Device was turned on after sleep, and colors and bitmaps probably were reset
 			g_dwAccent = NULL;
 		}
-		if (message == WM_DWMCOLORIZATIONCOLORCHANGED || (message == WM_WTSSESSION_CHANGE && wParam == WTS_SESSION_UNLOCK)) {
+		if (message == WM_THEMECHANGED) {
+			accentColorChanges = 1;
+		}
+		else if (message == WM_DWMCOLORIZATIONCOLORCHANGED || (message == WM_WTSSESSION_CHANGE && wParam == WTS_SESSION_UNLOCK)) {
+			accentColorChanges++;
 			accentColorChanges++;
 		}
 		else {

--- a/AccentColorizer/main.cpp
+++ b/AccentColorizer/main.cpp
@@ -23,7 +23,7 @@ void ApplyAccentColorization()
 
 	ModifySysColors();
 	ModifyStyles();
-	hBitmapList.clear();
+	handledBitmaps.clear();
 }
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)

--- a/AccentColorizer/main.cpp
+++ b/AccentColorizer/main.cpp
@@ -8,6 +8,7 @@
 constexpr LPCWSTR szWindowClass = L"ACCENTCOLORIZER";
 HANDLE hMutex;
 int accentColorChanges = 0;
+int dpiChange = 0;
 
 void ApplyAccentColorization()
 {
@@ -21,7 +22,9 @@ void ApplyAccentColorization()
 		return;
 	}
 
-	ModifySysColors();
+	if (dpiChange == 0) {
+		ModifySysColors();
+	}
 	ModifyStyles();
 	handledBitmaps.clear();
 }
@@ -29,7 +32,7 @@ void ApplyAccentColorization()
 LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	if (message == WM_DWMCOLORIZATIONCOLORCHANGED ||
-		message == WM_THEMECHANGED ||
+		message == WM_THEMECHANGED || message == WM_DPICHANGED ||
 		(message == WM_WTSSESSION_CHANGE && wParam == WTS_SESSION_UNLOCK)
 		)
 	{


### PR DESCRIPTION
This new version allows you to use any accent color, such as gray, brown, etc. Designed to colorize the default Windows 11 visual style and Rectify11's custom visual styles. Does not have the Windows version checks apart from the taskband ExtendedUI buttons.